### PR TITLE
implement github actions workflows for push and pull_request

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,13 @@
+
+on: [push, pull_request]
+
+name: 'Shellcheck'
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -1,0 +1,268 @@
+on: [push, pull_request]
+
+name: 'Test action for tools'
+
+env:
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: master
+  MAX_CHUNKS: 4
+
+jobs:
+
+  setup-pr-tools:
+    name: Setup as in PR for tools
+    runs-on: ubuntu-latest
+    outputs:
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      tool-list: ${{ steps.discover.outputs.tool-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Print github context properties
+      run: |
+        echo 'event: ${{ github.event_name }}'
+        echo 'sha: ${{ github.sha }}'
+        echo 'ref: ${{ github.ref }}'
+        echo 'head_ref: ${{ github.head_ref }}'
+        echo 'base_ref: ${{ github.base_ref }}'
+        echo 'event.before: ${{ github.event.before }}'
+        echo 'event.after: ${{ github.event.after }}'
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    - name: Cache .planemo
+      uses: actions/cache@v2
+      id: cache-planemo
+      with:
+        path: ~/.planemo
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    # Install the `wheel` package so that when installing other packages which
+    # are not available as wheels, pip will build a wheel for them, which can be cached.
+    - name: Install wheel
+      run: pip install wheel
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Introduce a change on test tool1
+      run: |
+        git config --global user.name "Arthur Dent"
+        git config --global user.email "a.dent@galaxyproject.org"
+        echo "" >> test/tools/tool1/tool1.xml
+        git commit -m bump test/tools/tool1/tool1.xml
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: ./
+      id: discover
+      with:
+        create-cache: ${{ steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true' }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+    - name: Check commit range
+      run: if ! grep "\.\." <<<$(echo ${{ steps.discover.outputs.commit-range }}); then echo "wrong commit range"; exit 1; fi
+    - name: Check content of repository list
+      run: |
+        if ! grep -q "tool1" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool1 must be in repo list"; exit 1; fi
+        if grep -q "tool2" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool2 must not be in repo list"; exit 1; fi
+    - name: Check content of tool list
+      run: |
+        if ! grep -q "tool1.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool1.xml must be in tool list"; exit 1; fi
+        if grep -q "tool2.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool2.xml must not be in tool list"; exit 1; fi
+    - name: Check number of chunks
+      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "1" ]; then echo "wrong chunk-count"; exit 1; fi
+
+  setup-ci-tools:
+    name: Setup as in CI for tools
+    runs-on: ubuntu-latest
+    outputs:
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+      fork: ${{ steps.get-fork-branch.outputs.fork }}
+      branch: ${{ steps.get-fork-branch.outputs.branch }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    # Install the `wheel` package so that when installing other packages which
+    # are not available as wheels, pip will build a wheel for them, which can be cached.
+    - name: Install wheel
+      run: pip install wheel
+    - uses: actions/checkout@v2
+      with:
+        # TODO main
+        ref: master
+        fetch-depth: 1
+    - name: Artificially exclude workflows (because ci_find_repos discovers tool and workflow repos)
+      run: echo 'test/workflows/' > .tt_skip
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: ./
+      id: discover
+      env:
+        GITHUB_EVENT_NAME: schedule
+      with:
+        create-cache: true
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+        github-event-name-override: 'schedule'
+    - name: Check for empty commit range
+      run: if [ -n "${{ steps.discover.outputs.commit-range }}" ]; then exit 1; fi
+    # note: ci_find_repos will find all tools and workflows
+    - name: Check that all tools an workflows are in the repository list
+      run: |
+        if ! grep -q "tool1" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool1 must be in the repo list"; exit 1; fi
+        if ! grep -q "tool2" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool2 must be in the repo list"; exit 1; fi
+        if grep -q "example3" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example3 must not be in the repo list"; exit 1; fi
+        if grep -q "example4" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example4 must not be in the repo list"; exit 1; fi
+    # note: ci_find_tools will find onlytools
+    - name: Check that all tools are in the tool list
+      run: |
+        if ! grep -q "tool1.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool1.xml must be in the repo list"; exit 1; fi
+        if ! grep -q "tool2.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool2.xml must be in the repo list"; exit 1; fi
+    # chunk-count will only consider tools/workflows depending on the workflow input to the action
+    - name: Check that the number of chunks is two, i.e. the number of tools
+      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "2" ]; then exit 1; fi
+
+  lint:
+    name: Test linting of tools
+    needs: [setup-ci-tools]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-tools.outputs.galaxy-head-sha }}
+    - name: Install wheel
+      run: pip install wheel
+    - name: Planemo lint tools
+      uses: ./
+      with:
+        mode: lint
+        repository-list: ${{ needs.setup-ci-tools.outputs.repository-list }}
+        tool-list: ${{ needs.setup-ci-tools.outputs.tool-list }}
+
+  test-tools:
+    name: Test testing of tools
+    needs: [setup-ci-tools]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJson(needs.setup-ci-tools.outputs.chunk-list) }}
+        python-version: [3.7]
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+    # checkout the repository
+    # and use it as the current working directory
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-tools.outputs.galaxy-head-sha }}
+    - name: Planemo test tools
+      uses: ./
+      id: test-tools
+      with:
+        mode: test
+        repository-list: ${{ needs.setup-ci-tools.outputs.repository-list }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup-ci-tools.outputs.chunk-count }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'Tool test output ${{ matrix.chunk }}'
+        path: upload
+
+  combine_outputs:
+    name: Test combining 'chunked' test results
+    needs: [setup-ci-tools, test-tools]
+    strategy:
+      matrix:
+        python-version: [3.7]
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-tools.outputs.galaxy-head-sha }}
+    - name: Combine outputs
+      uses: ./
+      id: combine
+      with:
+        mode: combine
+        html-report: true
+    - name: Check statistics
+      run: if ! grep -q "2\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'All tool test results'
+        path: upload
+    - name: Check outputs
+      uses: ./
+      id: check
+      with:
+        mode: check

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,0 +1,276 @@
+
+on: [push, pull_request]
+
+name: 'Test action for workflows'
+
+env:
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: master
+  MAX_CHUNKS: 4
+
+jobs:
+
+  setup-pr-workflows:
+    name: Setup as in PR for workflows
+    runs-on: ubuntu-latest
+    outputs:
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      tool-list: ${{ steps.discover.outputs.tool-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Print github context properties
+      run: |
+        echo 'event: ${{ github.event_name }}'
+        echo 'sha: ${{ github.sha }}'
+        echo 'ref: ${{ github.ref }}'
+        echo 'head_ref: ${{ github.head_ref }}'
+        echo 'base_ref: ${{ github.base_ref }}'
+        echo 'event.before: ${{ github.event.before }}'
+        echo 'event.after: ${{ github.event.after }}'
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    - name: Cache .planemo
+      uses: actions/cache@v2
+      id: cache-planemo
+      with:
+        path: ~/.planemo
+        key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    # Install the `wheel` package so that when installing other packages which
+    # are not available as wheels, pip will build a wheel for them, which can be cached.
+    - name: Install wheel
+      run: pip install wheel
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Introduce a change on a test workflow
+      run: |
+        git config --global user.name "Arthur Dent"
+        git config --global user.email "a.dent@galaxyproject.org"
+        echo "" >> test/workflows/example3/tutorial.ga
+        git commit -m bump test/workflows/example3/tutorial.ga
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: ./
+      id: discover
+      with:
+        workflows: true
+        # TODO remove planemo-version
+        planemo-version: https://github.com/galaxyproject/planemo/archive/18a41d3a67a0df5b816c8b5ebb5e94d292dd9481.zip
+        create-cache: ${{ steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true' }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+    - name: Check commit range
+      run: if ! grep "\.\." <<<$(echo ${{ steps.discover.outputs.commit-range }}); then echo "wrong commit range"; exit 1; fi
+    - name: Check content of repository list
+      run: |
+        if ! grep -q "example3" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example3 must be in repo list"; exit 1; fi
+        if grep -q "example4" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example4 must not be in repo list"; exit 1; fi
+    - name: Check content of tool list
+      run: if [ -n "${{ steps.discover.outputs.tool-list }}" ]; then echo "tool list must be empty"; exit 1; fi
+    - name: Check number of chunks
+      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "1" ]; then echo "wrong chunk-count"; fi
+  
+  setup-ci-workflows:
+    name: Setup as in CI for workflows
+    runs-on: ubuntu-latest
+    outputs:
+      galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+      fork: ${{ steps.get-fork-branch.outputs.fork }}
+      branch: ${{ steps.get-fork-branch.outputs.branch }}
+      repository-list: ${{ steps.discover.outputs.repository-list }}
+      chunk-count: ${{ steps.discover.outputs.chunk-count }}
+      chunk-list: ${{ steps.discover.outputs.chunk-list }}
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - name: Determine latest commit in the Galaxy repo
+      id: get-galaxy-sha
+      run: echo "::set-output name=galaxy-head-sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
+    # Install the `wheel` package so that when installing other packages which
+    # are not available as wheels, pip will build a wheel for them, which can be cached.
+    - name: Install wheel
+      run: pip install wheel
+    - uses: actions/checkout@v2
+      with:
+        # TODO main
+        ref: master
+        fetch-depth: 1
+    - name: Artificially exclude tools (because ci_find_repos discovers tool and workflow repos)
+      run: echo 'test/tools/' > .tt_skip
+    - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
+      uses: ./
+      id: discover
+      env:
+        GITHUB_EVENT_NAME: schedule
+      with:
+        workflows: true
+        create-cache: true
+        # TODO remove planemo-version
+        planemo-version: https://github.com/galaxyproject/planemo/archive/18a41d3a67a0df5b816c8b5ebb5e94d292dd9481.zip
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
+        github-event-name-override: 'schedule'
+    - name: Check for empty commit range
+      run: if [ -n "${{ steps.discover.outputs.commit-range }}" ]; then exit 1; fi
+    # note: ci_find_repos will find all tools and workflows
+    - name: Check that all tools an workflows are in the repository list
+      run: |
+        if grep -q "tool1" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool1 must not be in the repo list"; exit 1; fi
+        if grep -q "tool2" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "tool2 must not be in the repo list"; exit 1; fi
+        if ! grep -q "example3" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example3 must be in the repo list"; exit 1; fi
+        if ! grep -q "example4" <<<$(echo "${{ steps.discover.outputs.repository-list }}"); then echo "example4 must be in the repo list"; exit 1; fi
+    # note: ci_find_tools will find only tools, i.e. it should be empty here
+    - name: Check that all tools are in the tool list
+      run: if [ -n "${{ steps.discover.outputs.tool-list }}" ]; then exit 1; fi
+    # chunk-count will only consider tools/workflows depending on the workflow input to the action
+    - name: Check that the number of chunks is two, i.e. the number of tools
+      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "2" ]; then exit 1; fi
+
+  lint:
+    name: Test linting of workflows
+    needs: [setup-ci-workflows]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-workflows.outputs.galaxy-head-sha }}
+    - name: Install wheel
+      run: pip install wheel
+    - name: Planemo lint workflows
+      uses: ./
+      with:
+        mode: lint
+        workflows: true
+        repository-list: "${{ needs.setup-ci-workflows.outputs.repository-list }}"
+        tool-list: "${{ needs.setup-ci-workflows.outputs.tool-list }}"
+
+  test-workflows:
+    name: Test testing of workflows
+    needs: [setup-ci-workflows]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJson(needs.setup-ci-workflows.outputs.chunk-list) }}
+        python-version: [3.7]
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+    # checkout the repository
+    # and use it as the current working directory
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-workflows.outputs.galaxy-head-sha }}
+    - name: Planemo test workflows
+      uses: ./
+      id: test-workflows
+      with:
+        mode: test
+        workflows: true
+        setup-cvmfs: true
+        # TODO remove planemo-version
+        planemo-version: https://github.com/galaxyproject/planemo/archive/18a41d3a67a0df5b816c8b5ebb5e94d292dd9481.zip
+        repository-list: ${{ needs.setup-ci-workflows.outputs.repository-list }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'Workflow test output ${{ matrix.chunk }}'
+        path: upload
+
+  combine_outputs:
+    name: Test combining 'chunked' test results
+    needs: [setup-ci-workflows, test-workflows]
+    strategy:
+      matrix:
+        python-version: [3.7]
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-tools.outputs.galaxy-head-sha }}
+    - name: Combine outputs
+      uses: ./
+      id: combine
+      with:
+        mode: combine
+        html-report: true
+    - name: Check statistics
+      run: if ! grep -q "2\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'All tool test results'
+        path: upload
+    - name: Check outputs
+      uses: ./
+      id: check
+      with:
+        mode: check

--- a/test/tools/tool1/.shed.yml
+++ b/test/tools/tool1/.shed.yml
@@ -1,0 +1,4 @@
+categories: [Sequence Analysis]
+description: tool1
+name: tool1
+owner: adent

--- a/test/tools/tool1/tool1.xml
+++ b/test/tools/tool1/tool1.xml
@@ -1,0 +1,38 @@
+<tool id="test1" name="test1" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01" license="MIT">
+    <description>test1</description>
+    <macros>
+        <token name="@TOOL_VERSION@">0.1.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+    </macros>
+    <command detect_errors="exit_code"><![CDATA[
+        echo test > '$out'
+    ]]></command>
+    <inputs>
+        <param argument="bool" type="boolean" truevalue="bool" falsevalue="" label="" help="TODO" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="bool" value="true"/>
+            <output name="out">
+                <assert_contents>
+                    <has_text text="test"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+**Input**
+
+
+**Output**
+
+
+    ]]></help>
+    <citations>
+        <citation type="doi">blah</citation>
+    </citations>
+</tool>

--- a/test/tools/tool2/.shed.yml
+++ b/test/tools/tool2/.shed.yml
@@ -1,0 +1,4 @@
+categories: [Sequence Analysis]
+description: tool2
+name: tool2
+owner: adent

--- a/test/tools/tool2/tool2.xml
+++ b/test/tools/tool2/tool2.xml
@@ -1,0 +1,38 @@
+<tool id="test2" name="test2" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01" license="MIT">
+    <description>test2</description>
+    <macros>
+        <token name="@TOOL_VERSION@">0.1.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+    </macros>
+    <command detect_errors="exit_code"><![CDATA[
+        echo test > '$out'
+    ]]></command>
+    <inputs>
+        <param argument="bool" type="boolean" truevalue="bool" falsevalue="" label="" help="TODO" />
+    </inputs>
+    <outputs>
+        <data name="out" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="bool" value="true"/>
+            <output name="out">
+                <assert_contents>
+                    <has_text text="test"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+**Input**
+
+
+**Output**
+
+
+    ]]></help>
+    <citations>
+        <citation type="doi">blah</citation>
+    </citations>
+</tool>

--- a/test/workflows/example3/.dockstore.yml
+++ b/test/workflows/example3/.dockstore.yml
@@ -1,0 +1,7 @@
+version: 1.2
+workflows:
+- name: "example3"
+  primaryDescriptorPath: /tutorial.ga
+  subclass: Galaxy
+  testParameterFiles:
+  - /tutorial-tests.yml

--- a/test/workflows/example3/data/dataset1.txt
+++ b/test/workflows/example3/data/dataset1.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/test/workflows/example3/data/dataset2.txt
+++ b/test/workflows/example3/data/dataset2.txt
@@ -1,0 +1,3 @@
+this
+is
+dataset 2

--- a/test/workflows/example3/data/output.txt
+++ b/test/workflows/example3/data/output.txt
@@ -1,0 +1,3 @@
+is
+hello
+world

--- a/test/workflows/example3/output.json
+++ b/test/workflows/example3/output.json
@@ -1,0 +1,1 @@
+{"output": {"class": "File", "path": "/home/berntm/projects/usegalaxy-eu/workflow-testing/example3/tutorial_output.txt", "checksum": "sha1$4d7ab2b2bb0102ee5ec472a5971ca86081ff700c", "size": 15, "basename": "tutorial_output.txt", "nameroot": "tutorial_output", "nameext": ".txt"}}

--- a/test/workflows/example3/tools.yml
+++ b/test/workflows/example3/tools.yml
@@ -1,0 +1,5 @@
+install_tool_dependencies: True
+install_repository_dependencies: True
+install_resolver_dependencies: True
+
+tools: []

--- a/test/workflows/example3/tutorial-job.yml
+++ b/test/workflows/example3/tutorial-job.yml
@@ -1,0 +1,7 @@
+Dataset 1:
+  class: File
+  path: "data/dataset1.txt"
+Dataset 2:
+  class: File
+  path: "data/dataset2.txt"
+Number of lines: 3

--- a/test/workflows/example3/tutorial-tests.yml
+++ b/test/workflows/example3/tutorial-tests.yml
@@ -1,0 +1,13 @@
+- doc: Test outline for tutorial.ga
+  job:
+    Dataset 1:
+      class: File
+      path: "data/dataset1.txt"
+    Dataset 2:
+      class: File
+      path: "data/dataset2.txt"
+    Number of lines: 3
+  outputs:
+    output:
+      class: File
+      path: "data/output.txt"

--- a/test/workflows/example3/tutorial.ga
+++ b/test/workflows/example3/tutorial.ga
@@ -1,0 +1,228 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "planemo run tutorial",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 2"
+                }
+            ],
+            "label": "Dataset 2",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 355.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 294,
+                "width": 200,
+                "x": 348.5,
+                "y": 294
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "004a6ce7-a8f3-4a54-b513-e1456a3695e8",
+            "workflow_outputs": [
+                {
+                    "label": "Dataset 2",
+                    "output_name": "output",
+                    "uuid": "05042d8c-8f06-4646-81ba-1f4ffb858ad3"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 1"
+                }
+            ],
+            "label": "Dataset 1",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 455.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 394,
+                "width": 200,
+                "x": 348.5,
+                "y": 394
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "b42b2137-033e-4e7e-849e-21def05f4a70",
+            "workflow_outputs": [
+                {
+                    "label": "Dataset 1",
+                    "output_name": "output",
+                    "uuid": "8c0a8c18-74d3-43c5-b3fa-8d1a3a4721b6"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Number of lines"
+                }
+            ],
+            "label": "Number of lines",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "bottom": 544.1999969482422,
+                "height": 82.19999694824219,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 462,
+                "width": 200,
+                "x": 626.5,
+                "y": 462
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "442ca31b-cdcf-46eb-815c-c23baf2c4dc5",
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "cat1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input1": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "queries_0|input2": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 424,
+                "height": 144,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 280,
+                "width": 200,
+                "x": 626.5,
+                "y": 280
+            },
+            "post_job_actions": {},
+            "tool_id": "cat1",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"input2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "860edbb3-b1dd-42a0-8edd-d4d3838ca916",
+            "workflow_outputs": [
+                {
+                    "label": "Concatenate datasets",
+                    "output_name": "out_file1",
+                    "uuid": "ca8c4181-931d-4ff2-98ae-19d9316f9fa4"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "random_lines1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 3,
+                    "output_name": "out_file1"
+                },
+                "num_lines": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select random lines",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Select random lines",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 464,
+                "height": 144,
+                "left": 904.5,
+                "right": 1104.5,
+                "top": 320,
+                "width": 200,
+                "x": 904.5,
+                "y": 320
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "tutorial_output.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "random_lines1",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.2",
+            "type": "tool",
+            "uuid": "2f32db91-1fdb-4a61-97e9-6aa3a63e45e2",
+            "workflow_outputs": [
+                {
+                    "label": "output",
+                    "output_name": "out_file1",
+                    "uuid": "22c0a13c-4aed-4874-a742-6753a77c505a"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "9ef02c65-d5b0-4380-8eac-567585f21a07",
+    "version": 2
+}

--- a/test/workflows/example3/tutorial_output.txt
+++ b/test/workflows/example3/tutorial_output.txt
@@ -1,0 +1,3 @@
+is
+hello
+world

--- a/test/workflows/example4/.dockstore.yml
+++ b/test/workflows/example4/.dockstore.yml
@@ -1,0 +1,7 @@
+version: 1.2
+workflows:
+- name: "example3"
+  primaryDescriptorPath: /tutorial.ga
+  subclass: Galaxy
+  testParameterFiles:
+  - /tutorial-tests.yml

--- a/test/workflows/example4/data/dataset1.txt
+++ b/test/workflows/example4/data/dataset1.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/test/workflows/example4/data/dataset2.txt
+++ b/test/workflows/example4/data/dataset2.txt
@@ -1,0 +1,3 @@
+this
+is
+dataset 2

--- a/test/workflows/example4/data/output.txt
+++ b/test/workflows/example4/data/output.txt
@@ -1,0 +1,3 @@
+is
+hello
+world

--- a/test/workflows/example4/output.json
+++ b/test/workflows/example4/output.json
@@ -1,0 +1,1 @@
+{"output": {"class": "File", "path": "/home/berntm/projects/usegalaxy-eu/workflow-testing/example3/tutorial_output.txt", "checksum": "sha1$4d7ab2b2bb0102ee5ec472a5971ca86081ff700c", "size": 15, "basename": "tutorial_output.txt", "nameroot": "tutorial_output", "nameext": ".txt"}}

--- a/test/workflows/example4/tools.yml
+++ b/test/workflows/example4/tools.yml
@@ -1,0 +1,5 @@
+install_tool_dependencies: True
+install_repository_dependencies: True
+install_resolver_dependencies: True
+
+tools: []

--- a/test/workflows/example4/tutorial-job.yml
+++ b/test/workflows/example4/tutorial-job.yml
@@ -1,0 +1,7 @@
+Dataset 1:
+  class: File
+  path: "data/dataset1.txt"
+Dataset 2:
+  class: File
+  path: "data/dataset2.txt"
+Number of lines: 3

--- a/test/workflows/example4/tutorial-tests.yml
+++ b/test/workflows/example4/tutorial-tests.yml
@@ -1,0 +1,13 @@
+- doc: Test outline for tutorial.ga
+  job:
+    Dataset 1:
+      class: File
+      path: "data/dataset1.txt"
+    Dataset 2:
+      class: File
+      path: "data/dataset2.txt"
+    Number of lines: 3
+  outputs:
+    output:
+      class: File
+      path: "data/output.txt"

--- a/test/workflows/example4/tutorial.ga
+++ b/test/workflows/example4/tutorial.ga
@@ -1,0 +1,228 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "planemo run tutorial",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 2"
+                }
+            ],
+            "label": "Dataset 2",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 355.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 294,
+                "width": 200,
+                "x": 348.5,
+                "y": 294
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "004a6ce7-a8f3-4a54-b513-e1456a3695e8",
+            "workflow_outputs": [
+                {
+                    "label": "Dataset 2",
+                    "output_name": "output",
+                    "uuid": "05042d8c-8f06-4646-81ba-1f4ffb858ad3"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Dataset 1"
+                }
+            ],
+            "label": "Dataset 1",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 455.8000030517578,
+                "height": 61.80000305175781,
+                "left": 348.5,
+                "right": 548.5,
+                "top": 394,
+                "width": 200,
+                "x": 348.5,
+                "y": 394
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "b42b2137-033e-4e7e-849e-21def05f4a70",
+            "workflow_outputs": [
+                {
+                    "label": "Dataset 1",
+                    "output_name": "output",
+                    "uuid": "8c0a8c18-74d3-43c5-b3fa-8d1a3a4721b6"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Number of lines"
+                }
+            ],
+            "label": "Number of lines",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "bottom": 544.1999969482422,
+                "height": 82.19999694824219,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 462,
+                "width": 200,
+                "x": 626.5,
+                "y": 462
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "442ca31b-cdcf-46eb-815c-c23baf2c4dc5",
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "cat1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input1": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "queries_0|input2": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 424,
+                "height": 144,
+                "left": 626.5,
+                "right": 826.5,
+                "top": 280,
+                "width": 200,
+                "x": 626.5,
+                "y": 280
+            },
+            "post_job_actions": {},
+            "tool_id": "cat1",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"input2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "860edbb3-b1dd-42a0-8edd-d4d3838ca916",
+            "workflow_outputs": [
+                {
+                    "label": "Concatenate datasets",
+                    "output_name": "out_file1",
+                    "uuid": "ca8c4181-931d-4ff2-98ae-19d9316f9fa4"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "random_lines1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 3,
+                    "output_name": "out_file1"
+                },
+                "num_lines": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select random lines",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Select random lines",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 464,
+                "height": 144,
+                "left": 904.5,
+                "right": 1104.5,
+                "top": 320,
+                "width": 200,
+                "x": 904.5,
+                "y": 320
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "tutorial_output.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "random_lines1",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.2",
+            "type": "tool",
+            "uuid": "2f32db91-1fdb-4a61-97e9-6aa3a63e45e2",
+            "workflow_outputs": [
+                {
+                    "label": "output",
+                    "output_name": "out_file1",
+                    "uuid": "22c0a13c-4aed-4874-a742-6753a77c505a"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "9ef02c65-d5b0-4380-8eac-567585f21a07",
+    "version": 2
+}

--- a/test/workflows/example4/tutorial_output.txt
+++ b/test/workflows/example4/tutorial_output.txt
@@ -1,0 +1,3 @@
+is
+hello
+world


### PR DESCRIPTION
implements three independent workflows

- seperate workflows for tools and workflows (necessary because artifacts would be mixed otherwise in the combine step)
- and one running shellcheck

I already tested this quite a bit. So I would suggest to merge this and test it in action for https://github.com/galaxyproject/planemo-ci-action/pull/3 (some shell check errors will need to be fixed. but I think I know how to do it).