### PR TITLE
checkout local action in all jobs and shellcheck fixes

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -237,6 +237,9 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
     - uses: actions/download-artifact@v2
       with:
         path: artifacts

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -116,8 +116,6 @@ jobs:
       run: pip install wheel
     - uses: actions/checkout@v2
       with:
-        # TODO main
-        ref: master
         fetch-depth: 1
     - name: Artificially exclude workflows (because ci_find_repos discovers tool and workflow repos)
       run: echo 'test/workflows/' > .tt_skip

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -245,6 +245,9 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
     - uses: actions/download-artifact@v2
       with:
         path: artifacts

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -118,8 +118,6 @@ jobs:
       run: pip install wheel
     - uses: actions/checkout@v2
       with:
-        # TODO main
-        ref: master
         fetch-depth: 1
     - name: Artificially exclude tools (because ci_find_repos discovers tool and workflow repos)
       run: echo 'test/tools/' > .tt_skip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs planemo, discovers changed workflows and tools, and allows to lint, tes
 The reference use cases of this action are the [pull request](https://github.com/galaxyproject/tools-iuc/blob/master/.github/workflows/pr.yaml) and [continuous integration](https://github.com/galaxyproject/tools-iuc/blob/master/.github/workflows/ci.yaml) workflows of the [intergalactic utility comission (IUC)](https://github.com/galaxyproject/tools-iuc/).
 
 
-The action runs in one of six modes which are controled with the `mode` inputs. Possible values are:
+The action runs in one of six modes which are controled with the `mode` input. Possible values are:
 
 - `setup`: This is the default. 
   - Optionally do a fake `planemo test` run to fill `.cache/pip`  and `.planemo` for caching.
@@ -16,13 +16,13 @@ The action runs in one of six modes which are controled with the `mode` inputs. 
 - `lint`: Lint tools with `planemo shed_lint` (resp. workflows with `planemo workflow_lint`) and check presence of repository metadata files (`.shed.yml`).
 - `test`: Test tools or workflows with `planemo test`.
 - `combine`: Combine the outputs from individual tool tests (`planemo merge_test_reports`) and create html/markdown reports (`planemo test_reports`).
-- `check`: Check if any of the tests failed.
+- `check`: Check if any of the tool tests failed.
 - `deploy`: Deploy tools to a toolshed using `planemo shed_update` and workflows to a github namespace, resp.
 
-If none of these inputs is set then a setup mode runs.
+If none of these modes is set then a setup mode runs.
 
 In all modes required software will be installed automatically, i.e. `planemo` and `jq`. 
-The version of planemo can be controlled with the input `planemo-version` (default `"planemo"`).
+The version of planemo can be controlled with the input `planemo-version` (default `"planemo"`, i.e. the latest version).
 
 Assumptions
 -----------
@@ -47,10 +47,11 @@ Setup mode
 
 This mode runs if no other mode is selected. It:
 
-- runs `planemo test` on a mock tool (if `create-cache` is set to true)
-- determines the relevant set or repositories and tools with `planemo ci_find_repos` and `planemo ci_find_tools`, respectively.
-  - for push and pull_request events (using `GITHUB_EVENT_NAME`) tools and repos that changed in the commit range
-  - all tools and repos otherwise
+- runs `planemo test` on a mock tool (if `create-cache` is set to `true`)
+- determines the relevant set of tool/workflow repositories and tools with `planemo ci_find_repos` and `planemo ci_find_tools`, respectively.
+  - for push and pull_request events (using `GITHUB_EVENT_NAME`) tools and repositories that changed in the commit range
+  - all tools and repositories otherwise
+
 - calulates the number of chunks to use for tool testing and the
   list of chunks
 
@@ -66,7 +67,7 @@ Optional inputs:
 Outputs:
 
 - `commit-range`: The used commit range.
-- `tool-list`: List of tools.
+- `tool-list`: List of tools (empty if `workflows` is `true`).
 - `repository-list` List of repositories.
 - `chunk-count`: Number of chunks to use.
 - `chunk-list`: List of chunks
@@ -86,7 +87,7 @@ Test mode
 
 Runs `planemo test` for each tool in a chunk using `ci_find_tools`. Note that none of the tests
 will produce a non-zero exit code even if the tests fail. Success needs to be checked with the
-"check outputs" mode after combining the outputs of the chunks.
+`check` mode after combining the outputs of the chunks.
 
 Inputs:
 
@@ -134,7 +135,7 @@ Check the combined outputs for failed test runs. If a failed test is found exit 
 
 Input:
 
-`upload/tool_test_output.json`
+tool test results in `upload/tool_test_output.json`
 
 Output:
 


### PR DESCRIPTION
The first runs of the workflows failed to some extent: 

- the combine job missed the checkout that is needed to run `./` this is fixed in this PR ~.. but we won't see the effect in the PR .. but only when its merged~
- the `setup as in PR` jobs failed because the tools and workflows have been added in the same commit .. which violates some assumption of the test, i.e. which tools/workflows changed .. this does not happen normally
- [x] the shellcheck test shall also be fixed in this PR .. I hope that I used all those arrays correctly (the syntax appears still a bit odd to me)
- [x] what do you think about renaming `master` to `main` in this repo? We would (I hope) only need to change https://github.com/galaxyproject/planemo-ci-action/blob/717a72fc3d823c15a089ae0625af448a67c7b3ca/.github/workflows/tools.yaml#L120 and https://github.com/galaxyproject/planemo-ci-action/blob/717a72fc3d823c15a089ae0625af448a67c7b3ca/.github/workflows/workflows.yaml#L122

I was also thinking

- if we should install python in the action (only for the setup and flake8 jobs we would need to have an [additional] python setup step)
- if we should have releases for this action?