### PR TITLE
count all tools in changed repo to get chunk count

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -65,16 +65,22 @@ if [ "$REPOSITORIES" == "" ] && [ "$MODE" == "setup" ]; then
 
   touch tool_list.txt
   if [ "$WORKFLOWS" != "true" ]; then
-    # TODO check: run ci_find_tools on complete repo has the advantage that it can be reused in the linting step
     planemo ci_find_tools "${PLANEMO_COMMIT_RANGE[@]}" --exclude packages --exclude deprecated --exclude_from .tt_skip --output tool_list.txt
     TOOLS=$(cat tool_list.txt)
-    # if [ -s repository_list.txt ]; then
-    #   planemo ci_find_tools --output tool_list.txt $(cat repository_list.txt)
-    # fi
   fi
 
+  # determine the number of chunks to use as linear function of the number of
+  # tested tools (i.e. all tools in the changed repos)
   if [ "$WORKFLOWS" != "true" ]; then
-    ln -s tool_list.txt count_list.txt
+    if [ -s repository_list.txt ]; then
+      if [ -n "$COMMIT_RANGE" ]; then
+        mapfile -t REPO_ARRAY < repository_list.txt
+        planemo ci_find_tools --output count_list.txt "${REPO_ARRAY[@]}" 
+      else
+        ln -s tool_list.txt count_list.txt
+      fi
+    fi
+    touch count_list.txt
   else
     ln -s repository_list.txt count_list.txt
   fi


### PR DESCRIPTION
currently the chunk count depends only on the number of changed tools.
but the tool test uses all tools in the changed repos. therefore the
computed number of chunks is to low.

for the linting step we still need the changed tools (for the .shed.yml
test).

for CI (i.e. when $COMMIT_RANGE is empty) the two calls to ci_find_tools
yield identical results and we might think about saving one...