### PR TITLE
add pipefail

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -8,7 +8,6 @@ env:
   MAX_CHUNKS: 4
 
 jobs:
-
   setup-pr-tools:
     name: Setup as in PR for tools
     runs-on: ubuntu-latest

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -178,10 +178,11 @@ jobs:
         repository-list: ${{ needs.setup-ci-tools.outputs.repository-list }}
         tool-list: ${{ needs.setup-ci-tools.outputs.tool-list }}
     - name: check if all test tools were linted
+      if: ${{ always() }}
       run: |
         grep tool1 lint_report.txt
         grep tool2 lint_report.txt
-      
+        grep "ERROR: Error '404 Client Error:" lint_report.txt
 
   test-tools:
     name: Test testing of tools

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -182,7 +182,7 @@ jobs:
       run: |
         grep tool1 lint_report.txt
         grep tool2 lint_report.txt
-        grep "ERROR: Error '404 Client Error:" lint_report.txt
+        grep "ERROR: Error 'HTTPConnectionPool" lint_report.txt
 
   test-tools:
     name: Test testing of tools

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -exo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init")

--- a/test/tools/tool2/tool2.xml
+++ b/test/tools/tool2/tool2.xml
@@ -27,6 +27,9 @@
 
 **Input**
 
+This will make the linter test fail.
+
+http://bugus.url/for_test
 
 **Output**
 


### PR DESCRIPTION
to make the action detect linter errors again.

recently (https://github.com/galaxyproject/planemo-ci-action/pull/15) a pipe was introduced to redirect linter output:

`planemo shed_lint ... | tee -a lint_report.txt`

without pipefail linter errors are not detected anymore.