### PR TITLE
support setting GALAXY_SLOTS

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -145,8 +145,8 @@ jobs:
         if ! grep -q "tool1.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool1.xml must be in the repo list"; exit 1; fi
         if ! grep -q "tool2.xml" <<<$(echo "${{ steps.discover.outputs.tool-list }}"); then echo "tool2.xml must be in the repo list"; exit 1; fi
     # chunk-count will only consider tools/workflows depending on the workflow input to the action
-    - name: Check that the number of chunks is two, i.e. the number of tools
-      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "2" ]; then exit 1; fi
+    - name: Check that the number of chunks is three, i.e. the number of tools
+      run: if [ "${{ steps.discover.outputs.chunk-count }}" != "3" ]; then exit 1; fi
 
   lint:
     name: Test linting of tools
@@ -217,6 +217,9 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup-ci-tools.outputs.galaxy-head-sha }}
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v1
+      id: cpu-cores
     - name: Planemo test tools
       uses: ./
       id: test-tools
@@ -228,6 +231,7 @@ jobs:
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-tools.outputs.chunk-count }}
         additional-planemo-options: --simultaneous_uploads --check_uploads_ok
+        galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
     - uses: actions/upload-artifact@v2
       with:
         name: 'Tool test output ${{ matrix.chunk }}'
@@ -264,7 +268,7 @@ jobs:
         mode: combine
         html-report: true
     - name: Check statistics
-      run: if ! grep -q "2\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
+      run: if ! grep -q "3\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
     - uses: actions/upload-artifact@v2
       with:
         name: 'All tool test results'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The version of planemo can be controlled with the input `planemo-version` (defau
 Assumptions
 -----------
 
-The action currently only works on workflows using an Ubuntu image.
+The action currently only works on github actions workflows using an Ubuntu image.
 
 Assumptions on the repository
 -----------------------------
@@ -112,6 +112,7 @@ Optional inputs:
 - `galaxy-source`
 - `python-version`
 - `additional-planemo-options`: additional options passed to `planemo test`, see for instance [here](https://github.com/galaxyproject/planemo-ci-action/blob/657582777416fc51b6171961d90dced7dacbeea2/.github/workflows/tools.yaml#L229)
+- `galaxy-slots`: number of slots (threads) to use in Galaxy jobs (sets the `GALAXY_SLOTS` environment variable)
 
 Output:
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,9 @@ inputs:
   additional-planemo-options:
     description: 'Additional options passed to planemo in lint/test mode'
     default: ''
+  galaxy-slots:
+    description: 'Number of cores to be used for Galaxy jobs in planemo test'
+    default: '1'
   # inputs that are needed for testing this action
   # not supposed to be used
   github-event-name-override:
@@ -132,6 +135,7 @@ runs:
         GITHUB_EVENT_NAME_OVERRIDE: ${{ inputs.github-event-name-override }}
         GITHUB_REF_OVERRIDE: ${{ inputs.github-ref-override }}
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
+        GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
 
     # see https://trstringer.com/github-actions-multiline-strings/
     - run: |

--- a/test/tools/galaxy_slots/.shed.yml
+++ b/test/tools/galaxy_slots/.shed.yml
@@ -1,0 +1,4 @@
+categories: [Sequence Analysis]
+description: test setting GALAXY_SLOTS
+name: galaxy_slots
+owner: adent

--- a/test/tools/galaxy_slots/galaxy_slots.xml
+++ b/test/tools/galaxy_slots/galaxy_slots.xml
@@ -1,0 +1,34 @@
+<tool id="galaxy_slots" name="galaxy_slots" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01" license="MIT">
+    <macros>
+        <token name="@TOOL_VERSION@">0.1.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+    </macros>
+    <command detect_errors="exit_code"><![CDATA[
+        echo "GALAXY_SLOTS \${GALAXY_SLOTS:-1}" > '$out'
+    ]]></command>
+    <inputs/>
+    <outputs>
+        <data name="out" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="out">
+                <assert_contents>
+                    <has_line line="GALAXY_SLOTS 1" negate="true"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+**Input**
+
+
+**Output**
+
+
+    ]]></help>
+    <citations>
+        <citation type="doi">blah</citation>
+    </citations>
+</tool>


### PR DESCRIPTION
this will enable that each Galaxy job started within planemo test can use more than the default of 1 CPU core

if I interpret the [docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)  correctly there should be 2 available in github hosted runners.

not sure if this is the best for workflow testing? is it possible in workflow tests to run multiple Galaxy jobs parallel? If so then we probably would like to set this in job_conf, or?
