### PR TITLE
add option to limit test run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Optional inputs:
 - `python-version`
 - `additional-planemo-options`: additional options passed to `planemo test`, see for instance [here](https://github.com/galaxyproject/planemo-ci-action/blob/657582777416fc51b6171961d90dced7dacbeea2/.github/workflows/tools.yaml#L229)
 - `galaxy-slots`: number of slots (threads) to use in Galaxy jobs (sets the `GALAXY_SLOTS` environment variable)
+- `test_default_wait`:  Maximum runtime of a single test in seconds, default: 0 means unlimited
 
 Output:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Optional inputs:
 - `python-version`
 - `additional-planemo-options`: additional options passed to `planemo test`, see for instance [here](https://github.com/galaxyproject/planemo-ci-action/blob/657582777416fc51b6171961d90dced7dacbeea2/.github/workflows/tools.yaml#L229)
 - `galaxy-slots`: number of slots (threads) to use in Galaxy jobs (sets the `GALAXY_SLOTS` environment variable)
-- `test_default_wait`:  Maximum runtime of a single test in seconds, default: 0 means unlimited
+- `test_timeout`:  Maximum runtime of a single test in seconds, default: 86400
 
 Output:
 

--- a/action.yml
+++ b/action.yml
@@ -74,9 +74,9 @@ inputs:
   galaxy-slots:
     description: 'Number of cores to be used for Galaxy jobs in planemo test'
     default: '1'
-  test_default_wait:
+  test_timeout:
     description: 'Maximum runtime of a single test in seconds, default: 0 means unlimited'
-    default: '0'
+    default: 86400
   # inputs that are needed for testing this action
   # not supposed to be used
   github-event-name-override:
@@ -147,7 +147,7 @@ runs:
         GITHUB_REF_OVERRIDE: ${{ inputs.github-ref-override }}
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
-        TEST_DEFAULT_WAIT: ${{ inputs.test_default_wait }}
+        TEST_TIMEOUT: ${{ inputs.test_timeout }}
 
     # see https://trstringer.com/github-actions-multiline-strings/
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,9 @@ inputs:
   galaxy-slots:
     description: 'Number of cores to be used for Galaxy jobs in planemo test'
     default: '1'
+  test_default_wait:
+    description: 'Maximum runtime of a single test in seconds, default: 0 means unlimited'
+    default: '0'
   # inputs that are needed for testing this action
   # not supposed to be used
   github-event-name-override:
@@ -144,6 +147,7 @@ runs:
         GITHUB_REF_OVERRIDE: ${{ inputs.github-ref-override }}
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
+        TEST_DEFAULT_WAIT: ${{ inputs.test_default_wait }}
 
     # see https://trstringer.com/github-actions-multiline-strings/
     - run: |

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION")
+PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_default_wait "$TEST_DEFAULT_WAIT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init")
 PLANEMO_WORKFLOW_OPTIONS=("--shed_tool_conf" "/cvmfs/main.galaxyproject.org/config/shed_tool_conf.xml" "--no_shed_install" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs")
 read -ra ADDITIONAL_PLANEMO_OPTIONS <<< "$ADDITIONAL_PLANEMO_OPTIONS"

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_default_wait "$TEST_DEFAULT_WAIT")
+PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init")
 PLANEMO_WORKFLOW_OPTIONS=("--shed_tool_conf" "/cvmfs/main.galaxyproject.org/config/shed_tool_conf.xml" "--no_shed_install" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs")
 read -ra ADDITIONAL_PLANEMO_OPTIONS <<< "$ADDITIONAL_PLANEMO_OPTIONS"


### PR DESCRIPTION
xref https://github.com/galaxyproject/planemo/pull/1236

alternatively we could just set the env variable and drop the referenced planemo PR .. not sure what is desired