### PR TITLE
prune docker containers (continuously)

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -3,8 +3,8 @@ set -exo pipefail
 
 # function running an infinite loop pruning (unused) docker images
 function background_prune_docker {
-  while 1; do
-    docker system prune --all --volumes --force
+  while true; do
+    docker system prune --all --volumes --force &> /dev/null
     sleep 60
   done
 }
@@ -161,7 +161,7 @@ if [ "$MODE" == "test" ]; then
   # show tools
   cat tool_list_chunk.txt
 
-  background_prune_docker &> /dev/null &
+  background_prune_docker &
   PRUNE_PID=$!
 
   # Test tools
@@ -189,6 +189,7 @@ if [ "$MODE" == "test" ]; then
   planemo test_reports tool_test_output.json --test_output tool_test_output.html
   
   mv tool_test_output.json tool_test_output.html upload/
+
   kill "$PRUNE_PID"
 fi
 

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -4,7 +4,7 @@ set -exo pipefail
 # function running an infinite loop pruning (unused) docker images
 function background_prune_docker {
   while 1; do
-    docker system prune --all --volumes
+    docker system prune --all --volumes --force
     sleep 60
   done
 }
@@ -161,7 +161,7 @@ if [ "$MODE" == "test" ]; then
   # show tools
   cat tool_list_chunk.txt
 
-  background_prune_docker &
+  background_prune_docker &> /dev/null &
   PRUNE_PID=$!
 
   # Test tools

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
+# function running an infinite loop pruning (unused) docker images
+function background_prune_docker {
+  while 1; do
+    docker system prune --all --volumes
+    sleep 60
+  done
+}
+
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
 PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs" --shed_tool_conf /tmp/shed_tool_conf.xml --shed_tool_path /tmp/shed_dir)
@@ -152,12 +160,14 @@ if [ "$MODE" == "test" ]; then
 
   # show tools
   cat tool_list_chunk.txt
-  
+
+  background_prune_docker &
+  PRUNE_PID=$!
+
   # Test tools
   mkdir -p json_output
   touch .tt_biocontainer_skip
   while read -r -a TOOL_GROUP; do
-    docker system prune --all --force --volumes || true
     # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
     if echo "${TOOL_GROUP[@]}" | grep -qf .tt_biocontainer_skip; then
       PLANEMO_OPTIONS=()
@@ -179,6 +189,7 @@ if [ "$MODE" == "test" ]; then
   planemo test_reports tool_test_output.json --test_output tool_test_output.html
   
   mv tool_test_output.json tool_test_output.html upload/
+  kill "$PRUNE_PID"
 fi
 
 # combine reports mode

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -157,6 +157,7 @@ if [ "$MODE" == "test" ]; then
   mkdir -p json_output
   touch .tt_biocontainer_skip
   while read -r -a TOOL_GROUP; do
+    docker system prune --all --force --volumes || true
     # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
     if echo "${TOOL_GROUP[@]}" | grep -qf .tt_biocontainer_skip; then
       PLANEMO_OPTIONS=()
@@ -168,7 +169,6 @@ if [ "$MODE" == "test" ]; then
     fi  
     json=$(mktemp -u -p json_output --suff .json)
     PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
-    docker system prune --all --force --volumes || true
   done < tool_list_chunk.txt
 
   if [ ! -s tool_list_chunk.txt ]; then


### PR DESCRIPTION
otherwise the 1st job does not profit from this

There was a recent discussion with @mvdbeek (https://github.com/galaxyproject/tools-iuc/pull/4935#issuecomment-1321759775) to do this in a loop running in the background. I thought about this: I think the problem is that the containers would be pruned also inbetween tests of the same tool / tool repo with the same requirements (and therefore the same container).