### PR TITLE
Install tools from shed

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
-PLANEMO_WORKFLOW_OPTIONS=("--shed_tool_conf" "/cvmfs/main.galaxyproject.org/config/shed_tool_conf.xml" "--no_shed_install" "--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--tool_data_path" "/cvmfs/data.galaxyproject.org/" "--docker_extra_volume" "/cvmfs")
+PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs")
 read -ra ADDITIONAL_PLANEMO_OPTIONS <<< "$ADDITIONAL_PLANEMO_OPTIONS"
 
 

--- a/test/workflows/example4/tutorial.ga
+++ b/test/workflows/example4/tutorial.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true",
     "annotation": "",
     "format-version": "0.1",
-    "name": "planemo run tutorial",
+    "name": "planemo run tutorial (imported from uploaded file)",
     "steps": {
         "0": {
             "annotation": "",
@@ -20,27 +20,16 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 355.8000030517578,
-                "height": 61.80000305175781,
-                "left": 348.5,
-                "right": 548.5,
-                "top": 294,
-                "width": 200,
-                "x": 348.5,
-                "y": 294
+                "left": 0,
+                "top": 3.5605316162109375
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "004a6ce7-a8f3-4a54-b513-e1456a3695e8",
-            "workflow_outputs": [
-                {
-                    "label": "Dataset 2",
-                    "output_name": "output",
-                    "uuid": "05042d8c-8f06-4646-81ba-1f4ffb858ad3"
-                }
-            ]
+            "when": null,
+            "workflow_outputs": []
         },
         "1": {
             "annotation": "",
@@ -58,27 +47,16 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 455.8000030517578,
-                "height": 61.80000305175781,
-                "left": 348.5,
-                "right": 548.5,
-                "top": 394,
-                "width": 200,
-                "x": 348.5,
-                "y": 394
+                "left": 0,
+                "top": 103.56053161621094
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "b42b2137-033e-4e7e-849e-21def05f4a70",
-            "workflow_outputs": [
-                {
-                    "label": "Dataset 1",
-                    "output_name": "output",
-                    "uuid": "8c0a8c18-74d3-43c5-b3fa-8d1a3a4721b6"
-                }
-            ]
+            "when": null,
+            "workflow_outputs": []
         },
         "2": {
             "annotation": "",
@@ -96,38 +74,38 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 544.1999969482422,
-                "height": 82.19999694824219,
-                "left": 626.5,
-                "right": 826.5,
-                "top": 462,
-                "width": 200,
-                "x": 626.5,
-                "y": 462
+                "left": 278,
+                "top": 171.56053161621094
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "442ca31b-cdcf-46eb-815c-c23baf2c4dc5",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
             "annotation": "",
-            "content_id": "cat1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
             "errors": null,
             "id": 3,
             "input_connections": {
-                "input1": {
+                "inputs": {
                     "id": 0,
                     "output_name": "output"
                 },
-                "queries_0|input2": {
+                "queries_0|inputs2": {
                     "id": 1,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Concatenate datasets",
+                    "name": "inputs"
+                }
+            ],
             "label": null,
             "name": "Concatenate datasets",
             "outputs": [
@@ -137,28 +115,23 @@
                 }
             ],
             "position": {
-                "bottom": 424,
-                "height": 144,
-                "left": 626.5,
-                "right": 826.5,
-                "top": 280,
-                "width": 200,
-                "x": 626.5,
-                "y": 280
+                "left": 278.35650634765625,
+                "top": 0.0
             },
             "post_job_actions": {},
-            "tool_id": "cat1",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"input2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"inputs\": {\"__class__\": \"RuntimeValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
             "type": "tool",
-            "uuid": "860edbb3-b1dd-42a0-8edd-d4d3838ca916",
-            "workflow_outputs": [
-                {
-                    "label": "Concatenate datasets",
-                    "output_name": "out_file1",
-                    "uuid": "ca8c4181-931d-4ff2-98ae-19d9316f9fa4"
-                }
-            ]
+            "uuid": "b2504aa6-746c-495d-a164-fd23e7f9b609",
+            "when": null,
+            "workflow_outputs": []
         },
         "4": {
             "annotation": "",
@@ -175,12 +148,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Select random lines",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Select random lines",
             "outputs": [
@@ -190,14 +158,8 @@
                 }
             ],
             "position": {
-                "bottom": 464,
-                "height": 144,
-                "left": 904.5,
-                "right": 1104.5,
-                "top": 320,
-                "width": 200,
-                "x": 904.5,
-                "y": 320
+                "left": 556,
+                "top": 29.560531616210938
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -209,10 +171,11 @@
                 }
             },
             "tool_id": "random_lines1",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": {\"__class__\": \"ConnectedValue\"}, \"seed_source\": {\"seed_source_selector\": \"set_seed\", \"__current_case__\": 1, \"seed\": \"0\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0.2",
             "type": "tool",
             "uuid": "2f32db91-1fdb-4a61-97e9-6aa3a63e45e2",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "output",
@@ -223,6 +186,6 @@
         }
     },
     "tags": [],
-    "uuid": "9ef02c65-d5b0-4380-8eac-567585f21a07",
-    "version": 2
+    "uuid": "8283a9a1-aadb-475c-9c1b-4ec75efad5ee",
+    "version": 1
 }


### PR DESCRIPTION
Given the long startup time when all tools are loaded from CVMFS this might be faster, tests against the IWC will run even if the tool is not (yet) installed on main, and non-iwc repos that don't necessarily have their tools installed on main can use this. Also drops the explicit `--tool_data_path` option, which was added for mounting in test data in the job container, but that's covered by `--docker_extra_volume` and should be faster at startup.