### PR TITLE
Keep shed_tool_conf and shed dir in between runs

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -271,7 +271,7 @@ jobs:
         mode: combine
         html-report: true
     - name: Check statistics
-      run: if ! grep -q "2\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
+      run: if ! grep -q "4\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
     - uses: actions/upload-artifact@v3
       with:
         name: 'All tool test results'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -223,6 +223,18 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
+    - name: 2nd run test workflows
+      uses: ./
+      id: test-workflows-2
+      with:
+        mode: test
+        workflows: true
+        setup-cvmfs: false
+        repository-list: ${{ needs.setup-ci-workflows.outputs.repository-list }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
     - uses: actions/upload-artifact@v3
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
-PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs")
+PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs" --shed_tool_conf /tmp/shed_tool_conf.xml --shed_tool_path /tmp/shed_dir)
 read -ra ADDITIONAL_PLANEMO_OPTIONS <<< "$ADDITIONAL_PLANEMO_OPTIONS"
 
 


### PR DESCRIPTION
Because we keep the same database connection Galaxy thinks repos are installed after the first workflow test, when they are not because planemo generated a new shed_tool_conf file. This fixes most of the tests in https://github.com/galaxyproject/iwc/pull/174