### PR TITLE
add tool_id and test_index to jq output

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -199,8 +199,7 @@ fi
 # check outputs mode
 # - check if there were unsuccessful tests
 if [ "$MODE" == "check" ]; then
-
-  if jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | grep -v "success"; then
+  if jq '.["tests"][]["data"] | {status: .status, id: .tool_id, idx: .test_index} | join(";")' tool_test_output.json | grep -v "success;"; then
     echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."
     exit 1
   fi


### PR DESCRIPTION
currently the combine step just outputs a set of "error" or "failure" strings for such tests. it would be much more useful to know immedately, i.e. without checking the html output, which tests failed.

this info should now be visible

just tested for the json output of
https://github.com/galaxyproject/tools-iuc/actions/runs/4798624079/jobs/8538223205 .. output looks like

```
...
"failure;mothur_remove_lineage;2"
"error;mothur_remove_lineage;3"
"error;mothur_remove_lineage;4"
"success;mothur_remove_otulabels;0"
...
```

Add a test? Not sure if it's worth to add an output, or possible to test stdout of an action? 