### PR TITLE
fix path for check mode

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -199,7 +199,7 @@ fi
 # check outputs mode
 # - check if there were unsuccessful tests
 if [ "$MODE" == "check" ]; then
-  if jq '.["tests"][]["data"] | {status: .status, id: .tool_id, idx: .test_index} | join(";")' tool_test_output.json | grep -v "success;"; then
+  if jq '.["tests"][]["data"] | {status: .status, id: .tool_id, idx: .test_index} | join(";")' upload/tool_test_output.json | grep -v "success;"; then
     echo "Unsuccessful tests found, inspect the 'All tool test results' artifact for details."
     exit 1
   fi


### PR DESCRIPTION
Problem was that 

```
if false | true; then
   echo F;
fi
```

does not fail, despite `pipefail`...

with `false` being `jq .. WRONG_PATH` in out case.

