### PR TITLE
Revert continuous pruning of containers

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-# function running an infinite loop pruning (unused) docker images
-function background_prune_docker {
-  while 1; do
-    docker system prune --all --volumes
-    sleep 60
-  done
-}
-
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
 PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs" --shed_tool_conf /tmp/shed_tool_conf.xml --shed_tool_path /tmp/shed_dir)
@@ -160,14 +152,12 @@ if [ "$MODE" == "test" ]; then
 
   # show tools
   cat tool_list_chunk.txt
-
-  background_prune_docker &
-  PRUNE_PID=$!
-
+  
   # Test tools
   mkdir -p json_output
   touch .tt_biocontainer_skip
   while read -r -a TOOL_GROUP; do
+    docker system prune --all --force --volumes || true
     # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
     if echo "${TOOL_GROUP[@]}" | grep -qf .tt_biocontainer_skip; then
       PLANEMO_OPTIONS=()
@@ -189,7 +179,6 @@ if [ "$MODE" == "test" ]; then
   planemo test_reports tool_test_output.json --test_output tool_test_output.html
   
   mv tool_test_output.json tool_test_output.html upload/
-  kill "$PRUNE_PID"
 fi
 
 # combine reports mode

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -4,7 +4,7 @@ set -exo pipefail
 # function running an infinite loop pruning (unused) docker images
 function background_prune_docker {
   while 1; do
-    docker system prune --all --volumes --force
+    docker system prune --all --volumes
     sleep 60
   done
 }
@@ -161,7 +161,7 @@ if [ "$MODE" == "test" ]; then
   # show tools
   cat tool_list_chunk.txt
 
-  background_prune_docker &> /dev/null &
+  background_prune_docker &
   PRUNE_PID=$!
 
   # Test tools

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -3,8 +3,8 @@ set -exo pipefail
 
 # function running an infinite loop pruning (unused) docker images
 function background_prune_docker {
-  while true; do
-    docker system prune --all --volumes --force &> /dev/null
+  while 1; do
+    docker system prune --all --volumes --force
     sleep 60
   done
 }
@@ -161,7 +161,7 @@ if [ "$MODE" == "test" ]; then
   # show tools
   cat tool_list_chunk.txt
 
-  background_prune_docker &
+  background_prune_docker &> /dev/null &
   PRUNE_PID=$!
 
   # Test tools
@@ -189,7 +189,6 @@ if [ "$MODE" == "test" ]; then
   planemo test_reports tool_test_output.json --test_output tool_test_output.html
   
   mv tool_test_output.json tool_test_output.html upload/
-
   kill "$PRUNE_PID"
 fi
 


### PR DESCRIPTION
Revert https://github.com/galaxyproject/planemo-ci-action/pull/37 and prune once before each `planemo test`.

When testing tools for which no container exists one is built. The continuous pruning makes this fail ([example](https://github.com/galaxyproject/tools-iuc/pull/5413)). It seems that also some `./build` directory is pruned and docker recreates it with root permissions ([see](https://github.com/galaxyproject/galaxy/blob/26031d6a401f1d57c4d3e0b5db2e86c65ab40445/lib/galaxy/tool_util/deps/mulled/mulled_build.py#L412)). Besides this it seems more than likely that a `prune` is called between subsequent tests and maybe even between building the container and using it in the test. Hence the container needs to be built frequently which often needs enormous amounts of time.... besides the fact that it does not work.

In addition before building the container, `conda search` call(s) are executed using some conda container. This container (approx 500MB) is pruned in between these searches. For tools like multigsea that have some requirements this leads to GBs of useless downloads (but maybe github uses some caching).


