### PR TITLE
allow setup of cvmfs in tool testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Required inputs:
 
 - `repository-list`: List of repositories
 - `workflows`: test workflows
-- `setup-cvmfs`: setup CVMFS (only useful for testing workflows)
+- `setup-cvmfs`: setup CVMFS (automatically set if workflows are tested. In most cases only useful for workflows, e.g. only in workflow mode docker binds will be setup.)
 - `chunk`: Current chunk
 - `chunk-count`: Maximum chunk
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Required inputs:
 
 - `repository-list`: List of repositories
 - `workflows`: test workflows
-- `setup-cvmfs`: setup CVMFS (automatically set if workflows are tested. In most cases only useful for workflows, e.g. only in workflow mode docker binds will be setup.)
+- `setup-cvmfs`: setup CVMFS (In most cases only useful for workflows, e.g. only in workflow mode docker binds will be setup.)
 - `chunk`: Current chunk
 - `chunk-count`: Maximum chunk
 

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -135,7 +135,7 @@ fi
 # - merge the test reports for the tool groups
 if [ "$MODE" == "test" ]; then
 
-  if [ "$WORKFLOWS" == "true" ] && [ "$SETUP_CVMFS" == "true" ]; then
+  if [ "$WORKFLOWS" == "true" ] || [ "$SETUP_CVMFS" == "true" ]; then
     "$GITHUB_ACTION_PATH"/cvmfs/setup_cvmfs.sh
   fi
 

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -135,7 +135,7 @@ fi
 # - merge the test reports for the tool groups
 if [ "$MODE" == "test" ]; then
 
-  if [ "$WORKFLOWS" == "true" ] || [ "$SETUP_CVMFS" == "true" ]; then
+  if [ "$SETUP_CVMFS" == "true" ]; then
     "$GITHUB_ACTION_PATH"/cvmfs/setup_cvmfs.sh
   fi
 


### PR DESCRIPTION
I have a repo where I would like to use the singularity images in a tool test.

And the used test parameters for workflow testing should imply the setup of cvmfs, or?