### PR TITLE
Fix lint job stopping early after first failure

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -175,7 +175,7 @@ jobs:
       with:
         mode: lint
         report-level: all
-        fail-level: error
+        fail-level: warn
         repository-list: ${{ needs.setup-ci-tools.outputs.repository-list }}
         tool-list: ${{ needs.setup-ci-tools.outputs.tool-list }}
         additional-planemo-options: --report_level all

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -113,12 +113,9 @@ if [ "$MODE" == "lint" ]; then
   mapfile -t REPO_ARRAY < repository_list.txt
   for DIR in "${REPO_ARRAY[@]}"; do
     if [ "$WORKFLOWS" != "true" ]; then
-      planemo shed_lint --tools --ensure_metadata --urls --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" --recursive "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt
+      (planemo shed_lint --tools --ensure_metadata --urls --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" --recursive "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt) || lint_fail=true
     else
-      planemo workflow_lint --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt
-    fi
-    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
-        lint_fail=true
+      (planemo workflow_lint --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt) || lint_fail=true
     fi
   done
   # Check if each changed tool is in the list of changed repositories

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -129,6 +129,7 @@ if [ "$MODE" == "lint" ]; then
   done
 fi
 
+
 # test mode
 # - compute grouped chunked tool list
 # - run `planemo test` each tool group

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -109,6 +109,7 @@ fi
 # - call `planemo lint` for each repo
 # - check if each tool is in a repo (i.e. if `.shed.yml` is present)
 if [ "$MODE" == "lint" ]; then
+  lint_fail=false
   mapfile -t REPO_ARRAY < repository_list.txt
   for DIR in "${REPO_ARRAY[@]}"; do
     if [ "$WORKFLOWS" != "true" ]; then
@@ -116,19 +117,23 @@ if [ "$MODE" == "lint" ]; then
     else
       planemo workflow_lint --report_level "$REPORT_LEVEL" --fail_level "$FAIL_LEVEL" "$DIR" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" | tee -a lint_report.txt
     fi
+    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+        lint_fail=true
+    fi
   done
-
   # Check if each changed tool is in the list of changed repositories
   mapfile -t TOOL_ARRAY < tool_list.txt
   for TOOL in "${TOOL_ARRAY[@]}"; do
     # Check if any changed repo dir is a substring of $TOOL
     if ! echo "$TOOL" | grep -qf repository_list.txt; then
       echo "Tool $TOOL not in changed repositories list: .shed.yml file missing" >&2
-      exit 1
+      lint_fail=true
     fi
   done
+  if $lint_fail; then
+    exit 1
+  fi
 fi
-
 
 # test mode
 # - compute grouped chunked tool list

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -127,7 +127,7 @@ if [ "$MODE" == "lint" ]; then
       lint_fail=true
     fi
   done
-  if $lint_fail; then
+  if [ "$lint_fail" = "true" ]; then
     exit 1
   fi
 fi


### PR DESCRIPTION
`planemo lint` breaks the loop after the first tool that fails linting. Hard to spot because most jobs contain a single tool and in the past we used `fail_level` `error` which happened seldomly for multiple tools.
