### PR TITLE
Fix stat call

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -199,7 +199,7 @@ if [ "$MODE" == "combine" ]; then
   [ "$PLANEMO_HTML_REPORT" == "true" ] && planemo test_reports upload/tool_test_output.json --test_output upload/tool_test_output.html
   [ "$PLANEMO_MD_REPORT" == "true" ] && (
     planemo test_reports upload/tool_test_output.json --test_output_markdown upload/tool_test_output.md
-    if [ "$(stat -f %z upload/tool_test_output.md)" -gt 1048576 ]; then
+    if [ "$(stat -c %s upload/tool_test_output.md)" -gt 1048576 ]; then
       planemo test_reports upload/tool_test_output.json --test_output_minimal_markdown upload/tool_test_output.md
     fi
   )


### PR DESCRIPTION
somehow this was completely messed up:

```
-f, --file-system     display file system status instead of file status

%z   time of last status change, human-readable
```

should be fine now:

```
-c  --format=FORMAT   use the specified FORMAT instead of the default;
                          output a newline after each use of FORMAT
%s   total size, in bytes
```