### PR TITLE
Upgrade GitHub Actions to use version 4 for upload and download artifacts

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -240,7 +240,7 @@ jobs:
         chunk-count: ${{ needs.setup-ci-tools.outputs.chunk-count }}
         additional-planemo-options: --simultaneous_uploads --check_uploads_ok
         galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: 'Tool test output ${{ matrix.chunk }}'
         path: upload
@@ -257,7 +257,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: artifacts
     - uses: actions/setup-python@v4
@@ -287,7 +287,7 @@ jobs:
           echo "${{ steps.combine.outputs.statistics }}";
           exit 1;
         fi
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: 'All tool test results'
         path: upload

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -235,7 +235,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'
         path: upload
@@ -252,7 +252,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: artifacts
     - uses: actions/setup-python@v4
@@ -272,7 +272,7 @@ jobs:
         html-report: true
     - name: Check statistics
       run: if ! grep -q "4\s\+success" <<<$(echo ${{ steps.combine.outputs.statistics }}); then echo "wrong statistics"; exit 1; fi
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: 'All tool test results'
         path: upload


### PR DESCRIPTION
xref:

Artifact actions v3 will be closing down by January 30, 2025. You are receiving this email because you have GitHub Actions workflows using v3 of actions/upload-artifact or actions/download-artifact. After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload. 