### PR TITLE
Test workflows against public instance

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -183,6 +183,7 @@ jobs:
     - name: check if all test tools were linted
       run: |
         set -x
+        cat lint_report.txt
         # check if the ToolIDValid linter is called (no of tools - 1 ) times, i.e. is skipped once
         if [ "$(grep -c ToolIDValid lint_report.txt)" != "3" ]; then
           echo "expecting exactly 2 tests for ToolIDValid"; exit 1; 

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -236,6 +236,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -238,7 +238,7 @@ jobs:
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
         # galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
       env:
-        IWC_API_KEY_USEGALAXY_EU: ${{ secrets.GALAXY_USER_KEY }}
+        IWC_API_KEY_USEGALAXY_EU: ${{ secrets.IWC_API_KEY_USEGALAXY_EU }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -236,7 +236,9 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+        # galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+      env:
+        IWC_API_KEY_USEGALAXY_EU: ${{ secrets.GALAXY_USER_KEY }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -236,9 +236,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        # galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
-      env:
-        IWC_API_KEY_USEGALAXY_EU: ${{ secrets.IWC_API_KEY_USEGALAXY_EU }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -223,6 +223,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - name: 2nd run test workflows
       uses: ./
       id: test-workflows-2

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -223,7 +223,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+        galaxy-user-key: ${{ secrets.GALAXY_API_KEYS }}
     - name: 2nd run test workflows
       uses: ./
       id: test-workflows-2
@@ -236,7 +236,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+        galaxy-user-key: ${{ secrets.GALAXY_API_KEYS }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -223,7 +223,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        galaxy-user-key: ${{ secrets.GALAXY_API_KEYS }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - name: 2nd run test workflows
       uses: ./
       id: test-workflows-2
@@ -236,7 +236,7 @@ jobs:
         galaxy-branch: ${{ env.GALAXY_BRANCH }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ needs.setup-ci-workflows.outputs.chunk-count }}
-        galaxy-user-key: ${{ secrets.GALAXY_API_KEYS }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Tools and workflows are discovered in all directories, except for `packages/` an
 
 A global `.lint_skip` file and per repo `.lint_skip` files can be used to list tool/workflow linters that should be skipped.
 
+For workflow repositories a `.wt_instance` contains the instance to run the workflow test against.
+In order to be able to use this an APII key for the instance needs to be passed to the test job
+via the `galaxy-user-key` parameter. At the moment only one instance is supported for the whole
+repository. 
+
+
+
+
+
 Setup mode
 ----------
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,18 @@ Tools and workflows are discovered in all directories, except for `packages/` an
 
 A global `.lint_skip` file and per repo `.lint_skip` files can be used to list tool/workflow linters that should be skipped.
 
-For workflow repositories a `.wt_instance` contains the instance to run the workflow test against.
-In order to be able to use this an APII key for the instance needs to be passed to the test job
-via the `galaxy-user-key` parameter. At the moment only one instance is supported for the whole
-repository. 
+For workflow repositories a `.wt_instance` contains the instance to run the workflow test against
+(note that the instance must not contain the trailing `https://`).
+In order to be able to use this, an API key for the instance used in the repo needs to be defined.
+If multiple instance are used in the repository (each `.wt_instance` can contain only one instance, 
+but multiple ones may be used for the whole repo) the secret can be json formatted as follows:
 
-
-
-
+```
+{
+    "usegalaxy.eu": "EU_API_KEY",
+    "usegalaxy.org": "ORG_API_KEY"
+}
+```
 
 Setup mode
 ----------

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A global `.lint_skip` file and per repo `.lint_skip` files can be used to list t
 
 For workflow repositories a `.wt_instance` contains the instance to run the workflow test against
 (note that the instance must not contain the trailing `https://`).
-In order to be able to use this, an API key for the instance used in the repo needs to be defined.
+In order to be able to use this, an API key for the instance used in the repo needs to be passed via `galaxy-user-key`.
 If multiple instance are used in the repository (each `.wt_instance` can contain only one instance, 
 but multiple ones may be used for the whole repo) the secret can be json formatted as follows:
 
@@ -133,6 +133,7 @@ Optional inputs:
 - `additional-planemo-options`: additional options passed to `planemo test`, see for instance [here](https://github.com/galaxyproject/planemo-ci-action/blob/657582777416fc51b6171961d90dced7dacbeea2/.github/workflows/tools.yaml#L229)
 - `galaxy-slots`: number of slots (threads) to use in Galaxy jobs (sets the `GALAXY_SLOTS` environment variable)
 - `test_timeout`:  Maximum runtime of a single test in seconds, default: 86400
+- `galaxy-user-key`: API key(s) used for testing agains online instances (note: use secrets for this). See "Assumptions on the repository".
 
 Output:
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Tools and workflows are discovered in all directories, except for `packages/` an
 
 A global `.lint_skip` file and per repo `.lint_skip` files can be used to list tool/workflow linters that should be skipped.
 
-For workflow repositories a `.wt_instance` contains the instance to run the workflow test against
-(note that the instance must not contain the trailing `https://`).
+For workflow repositories a `.wt_instance` file in a workflow folder contains the instance to run the workflow tests against
+(note that the instance must not contain the `https://` prefix).
 In order to be able to use this, an API key for the instance used in the repo needs to be passed via `galaxy-user-key`.
 If multiple instance are used in the repository (each `.wt_instance` can contain only one instance, 
 but multiple ones may be used for the whole repo) the secret can be json formatted as follows:

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,6 @@ runs:
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install planemo
       run: |
-        apt install yq
         pip install wheel ${{ inputs.planemo-version }}
         # Install Galaxy packages from a custom fork/branch if specified.
         # This allows testing against Galaxy development branches or forks.

--- a/action.yml
+++ b/action.yml
@@ -159,7 +159,7 @@ runs:
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
         TEST_TIMEOUT: ${{ inputs.test_timeout }}
-        GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
+        # GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
 
     - run: |
         echo 'repository-list<<EOF' >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,8 @@ inputs:
   github-ref-override:
     description: 'ONLY FOR TESTING: override GITHUB_REF'
     default: ''
+  galaxy-user-key:
+    default: ''
 
 outputs:
   commit-range:
@@ -157,6 +159,7 @@ runs:
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
         TEST_TIMEOUT: ${{ inputs.test_timeout }}
+        GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
 
     - run: |
         echo 'repository-list<<EOF' >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,7 @@ runs:
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install planemo
       run: |
+        apt install yq
         pip install wheel ${{ inputs.planemo-version }}
         # Install Galaxy packages from a custom fork/branch if specified.
         # This allows testing against Galaxy development branches or forks.
@@ -159,7 +160,7 @@ runs:
         ADDITIONAL_PLANEMO_OPTIONS: ${{ inputs.additional-planemo-options }}
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
         TEST_TIMEOUT: ${{ inputs.test_timeout }}
-        # GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
+        GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
 
     - run: |
         echo 'repository-list<<EOF' >> $GITHUB_OUTPUT

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -175,12 +175,12 @@ if [ "$MODE" == "test" ]; then
     fi
 
     ## TODO concatenating, ie TOOL_GROUP[*] might not work with multiple WF in a group
-    ## Can this happen?
-    if [ -f "${TOOL_GROUP[*]}/".tt_instance ]; then
-      INSTANCE=$(cat "${TOOL_GROUP[*]}/.tt_instance"  )
-      # INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
-      # KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$GALAXY_USER_KEY")
+    ## Can this happen??
+    if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
+      INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance"  )
+      INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
+      API_KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
+      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "${!API_KEY_VAR}")
     else
       PLANEMO_INSTANCE_OPTIONS=()
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -179,7 +179,7 @@ if [ "$MODE" == "test" ]; then
       INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance"  )
       # INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
       # KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE' --galaxy_user_key $GALAXY_USER_KEY"
+      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE --galaxy_user_key $GALAXY_USER_KEY"
     else
       PLANEMO_INSTANCE_OPTIONS=""
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -180,7 +180,8 @@ if [ "$MODE" == "test" ]; then
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
       set +x
-      export PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      export PLANEMO_GALAXY_USER_KEY
       echo "::add-mask::$PLANEMO_GALAXY_USER_KEY"
       set -x
       PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE")

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -162,7 +162,6 @@ if [ "$MODE" == "test" ]; then
   # Test tools
   mkdir -p json_output
   touch .tt_biocontainer_skip
-  
   while read -r -a TOOL_GROUP; do
     docker system prune --all --force --volumes || true
     # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP
@@ -185,7 +184,6 @@ if [ "$MODE" == "test" ]; then
     else
       PLANEMO_INSTANCE_OPTIONS=()
     fi
-
 
     json=$(mktemp -u -p json_output --suff .json)
     PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" "${PLANEMO_INSTANCE_OPTIONS[@]}" || true

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -177,8 +177,8 @@ if [ "$MODE" == "test" ]; then
     ## TODO concatenating, ie TOOL_GROUP[*] might not work with multiple WF in a group
     ## Can this happen??
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
-      INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance"  sed -e 's/\./_/g')
-      API_KEY=$(yq ".${INSTANCE}" <<<"$GALAXY_USER_KEY")
+      INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
+      API_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
       PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$API_KEY")
     else
       PLANEMO_INSTANCE_OPTIONS=()

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -exo pipefail
+
+set -exuo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
@@ -178,7 +179,10 @@ if [ "$MODE" == "test" ]; then
     ## Can this happen??
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
+      set +x
       export PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      echo "::add-mask::$PLANEMO_GALAXY_USER_KEY"
+      set -x
       PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE")
     else
       PLANEMO_INSTANCE_OPTIONS=()

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -176,10 +176,10 @@ if [ "$MODE" == "test" ]; then
     fi
 
     if [ -f "${TOOL_GROUP[@]}/".tt_instance ]; then
-      INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance")
+      INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance"  )
       INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
       KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS="--galaxy_url '$INSTANCE' --galaxy_user_key '${!KEY_VAR}'"
+      PLANEMO_INSTANCE_OPTIONS="--galaxy_url 'https://$INSTANCE' --galaxy_user_key '${!KEY_VAR}'"
     else
       PLANEMO_INSTANCE_OPTIONS=""
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -175,18 +175,20 @@ if [ "$MODE" == "test" ]; then
       PLANEMO_OPTIONS+=("${PLANEMO_WORKFLOW_OPTIONS[@]}")
     fi
 
-    if [ -f "${TOOL_GROUP[@]}/".tt_instance ]; then
-      INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance"  )
+    ## TODO concatenating, ie TOOL_GROUP[*] might not work with multiple WF in a group
+    ## Can this happen?
+    if [ -f "${TOOL_GROUP[*]}/".tt_instance ]; then
+      INSTANCE=$(cat "${TOOL_GROUP[*]}/.tt_instance"  )
       # INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
       # KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE --galaxy_user_key $GALAXY_USER_KEY"
+      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$GALAXY_USER_KEY")
     else
-      PLANEMO_INSTANCE_OPTIONS=""
+      PLANEMO_INSTANCE_OPTIONS=()
     fi
 
 
     json=$(mktemp -u -p json_output --suff .json)
-    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" $PLANEMO_INSTANCE_OPTIONS || true
+    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" "${PLANEMO_INSTANCE_OPTIONS[@]}" || true
   done < tool_list_chunk.txt
 
   if [ ! -s tool_list_chunk.txt ]; then

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -177,10 +177,9 @@ if [ "$MODE" == "test" ]; then
     ## TODO concatenating, ie TOOL_GROUP[*] might not work with multiple WF in a group
     ## Can this happen??
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
-      INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance"  )
-      INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
-      API_KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "${!API_KEY_VAR}")
+      INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance"  sed -e 's/\./_/g')
+      API_KEY=$(yq ".${INSTANCE}" <<<"$GALAXY_USER_KEY")
+      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$API_KEY")
     else
       PLANEMO_INSTANCE_OPTIONS=()
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -179,6 +179,7 @@ if [ "$MODE" == "test" ]; then
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
       API_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      echo "::add-mask::$API_KEY"
       PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$API_KEY")
     else
       PLANEMO_INSTANCE_OPTIONS=()

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -180,17 +180,16 @@ if [ "$MODE" == "test" ]; then
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
       set +x
-      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY" || $GALAXY_USER_KEY)"
       export PLANEMO_GALAXY_USER_KEY
       echo "::add-mask::$PLANEMO_GALAXY_USER_KEY"
       set -x
-      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE")
-    else
-      PLANEMO_INSTANCE_OPTIONS=()
+      PLANEMO_OPTIONS=("--galaxy_url" "https://$INSTANCE")
+      PLANEMO_TEST_OPTIONS=()
     fi
 
     json=$(mktemp -u -p json_output --suff .json)
-    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" "${PLANEMO_INSTANCE_OPTIONS[@]}" || true
+    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
   done < tool_list_chunk.txt
 
   if [ ! -s tool_list_chunk.txt ]; then

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -162,6 +162,16 @@ if [ "$MODE" == "test" ]; then
   # Test tools
   mkdir -p json_output
   touch .tt_biocontainer_skip
+  
+  if [ -f .tt_instance ]; then
+    INSTANCE=$(cat .tt_instance)
+    INSTANCE_UPPER=$(echo $INSTANCE | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
+    KEY_VAR="IWC_API_KEY_"$INSTANCE_UPPER
+    PLANEMO_INSTANCE_OPTIONS="--galaxy_url '$INSTANCE' --galaxy_user_key '${!KEY_VAR}'"
+  else
+    PLANEMO_INSTANCE_OPTIONS=""
+  fi 
+
   while read -r -a TOOL_GROUP; do
     docker system prune --all --force --volumes || true
     # Check if any of the lines in .tt_biocontainer_skip is a substring of $TOOL_GROUP

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -179,7 +179,7 @@ if [ "$MODE" == "test" ]; then
       INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance"  )
       INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
       KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS="--galaxy_url 'https://$INSTANCE' --galaxy_user_key '${!KEY_VAR}'"
+      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE' --galaxy_user_key ${!KEY_VAR}"
     else
       PLANEMO_INSTANCE_OPTIONS=""
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -exo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -177,9 +177,9 @@ if [ "$MODE" == "test" ]; then
 
     if [ -f "${TOOL_GROUP[@]}/".tt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[@]}/.tt_instance"  )
-      INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
-      KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
-      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE' --galaxy_user_key ${!KEY_VAR}"
+      # INSTANCE_UPPER=$(echo "$INSTANCE" | sed -e 's/\(.*\)/\U\1/g; s/\./_/g')
+      # KEY_VAR="IWC_API_KEY_$INSTANCE_UPPER"
+      PLANEMO_INSTANCE_OPTIONS="--galaxy_url https://$INSTANCE' --galaxy_user_key $GALAXY_USER_KEY"
     else
       PLANEMO_INSTANCE_OPTIONS=""
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -178,9 +178,8 @@ if [ "$MODE" == "test" ]; then
     ## Can this happen??
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
-      API_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
-      echo "::add-mask::$API_KEY"
-      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE" "--galaxy_user_key" "$API_KEY")
+      export PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY")"
+      PLANEMO_INSTANCE_OPTIONS=("--galaxy_url" "https://$INSTANCE")
     else
       PLANEMO_INSTANCE_OPTIONS=()
     fi

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -180,7 +180,7 @@ if [ "$MODE" == "test" ]; then
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
       set +x
-      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY" || echo $GALAXY_USER_KEY)"
+      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY" || echo "$GALAXY_USER_KEY")"
       export PLANEMO_GALAXY_USER_KEY
       echo "::add-mask::$PLANEMO_GALAXY_USER_KEY"
       set -x

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -180,7 +180,7 @@ if [ "$MODE" == "test" ]; then
     if [ -f "${TOOL_GROUP[*]}/".wt_instance ]; then
       INSTANCE=$(cat "${TOOL_GROUP[*]}/.wt_instance")
       set +x
-      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY" || $GALAXY_USER_KEY)"
+      PLANEMO_GALAXY_USER_KEY="$(jq -r --arg instance "$INSTANCE" '.[$instance]' <<<"$GALAXY_USER_KEY" || echo $GALAXY_USER_KEY)"
       export PLANEMO_GALAXY_USER_KEY
       echo "::add-mask::$PLANEMO_GALAXY_USER_KEY"
       set -x

--- a/test/workflows/example3/.tt_instance
+++ b/test/workflows/example3/.tt_instance
@@ -1,1 +1,0 @@
-usegalaxy.eu

--- a/test/workflows/example3/.tt_instance
+++ b/test/workflows/example3/.tt_instance
@@ -1,0 +1,1 @@
+usegalaxy.eu

--- a/test/workflows/example3/.wt_instance
+++ b/test/workflows/example3/.wt_instance
@@ -1,0 +1,1 @@
+usegalaxy.eu

--- a/test/workflows/example3/.wt_instance
+++ b/test/workflows/example3/.wt_instance
@@ -1,1 +1,1 @@
-usegalaxy.eu
+usegalaxy.org


### PR DESCRIPTION
- So far testing against one instance [seems to work](https://github.com/bernt-matthias/planemo-ci-action/pulls) 
- Originally I wanted to allow for multiple test instances, but I had no idea how to pass more than one secret to the CI action
  - Maybe we could make `.tt_instance` a json file (that specifies instances and secret variable names) that we could use in a [job matrix](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrix)  
- If we stay with a single instance it might make more sense to configure the instance in the workflow instead of in each workflow dir. 

TODO: 

- [x] docs