### PR TITLE
Add support for installing Galaxy packages from a specified branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Optional inputs:
 
 - `report_level`: all|warn|error (default: all)
 - `fail_level`: warn|error (default: error)
-- `additional-planemo-options`: additional options passed to `planemo lint`. [Here](https://github.com/galaxyproject/planemo-ci-action/blob/b8ede8dc7767a86ac8bae582554d18ea00863259/.github/workflows/tools.yaml#L179) this is used to overwrite the warn level of `planemo lint`. 
+- `additional-planemo-options`: additional options passed to `planemo lint`. [Here](https://github.com/galaxyproject/planemo-ci-action/blob/b8ede8dc7767a86ac8bae582554d18ea00863259/.github/workflows/tools.yaml#L179) this is used to overwrite the warn level of `planemo lint`.
+- `galaxy-branch`: Galaxy branch to use (default: `master`). Affects the pointing step and Galaxy package installation (for non-master/main branches).
+- `galaxy-fork`: Galaxy fork to use (default: `galaxyproject`). Affects the pointing step and Galaxy package installation (for non-master/main branches).
 
 Output:
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Optional inputs:
 - `report_level`: all|warn|error (default: all)
 - `fail_level`: warn|error (default: error)
 - `additional-planemo-options`: additional options passed to `planemo lint`. [Here](https://github.com/galaxyproject/planemo-ci-action/blob/b8ede8dc7767a86ac8bae582554d18ea00863259/.github/workflows/tools.yaml#L179) this is used to overwrite the warn level of `planemo lint`.
-- `galaxy-branch`: Galaxy branch to use (default: `master`). Affects the pointing step and Galaxy package installation (for non-master/main branches).
-- `galaxy-fork`: Galaxy fork to use (default: `galaxyproject`). Affects the pointing step and Galaxy package installation (for non-master/main branches).
+- `galaxy-branch`: Galaxy branch to test against (default: `master`). Used for Galaxy package installation when testing with non-master/main branches.
+- `galaxy-fork`: Galaxy fork to test against (default: `galaxyproject`). Used for Galaxy package installation when testing with non-master/main branches.
 
 Output:
 

--- a/action.yml
+++ b/action.yml
@@ -114,8 +114,11 @@ runs:
     - name: Install planemo
       run: |
         pip install wheel ${{ inputs.planemo-version }}
-        if [[ "${{ inputs.galaxy-branch }}" != "master" ]]; then
-          echo "Installing Galaxy packages from branch: ${{ inputs.galaxy-branch }}"
+        # Install Galaxy packages from a custom fork/branch if specified.
+        # This allows testing against Galaxy development branches or forks.
+        # Only runs when both fork and branch are provided, and branch is not master/main.
+        if [[ "${{ inputs.galaxy-fork }}" != "" && "${{ inputs.galaxy-branch }}" != "" && "${{ inputs.galaxy-branch }}" != "master" && "${{ inputs.galaxy-branch }}" != "main" ]]; then
+          echo "Installing Galaxy packages from fork ${{ inputs.galaxy-fork }}, branch ${{ inputs.galaxy-branch }}"
           base="git+https://github.com/${{ inputs.galaxy-fork }}/galaxy.git@${{ inputs.galaxy-branch }}#subdirectory=packages"
           pip install --force-reinstall "$base/util" "$base/tool_util_models" "$base/tool_util"
         fi

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@ inputs:
     description: 'Set a specific planemo version or url. If not specified installs latest planemo release from PyPI'
     default: 'planemo'
   galaxy-branch:
-    description: 'Galaxy branch to use'
+    description: 'Galaxy branch to use. Affects both the pointing step and Galaxy package installation.'
     default: 'master'
   galaxy-fork:
-    description: 'Galaxy fork to use'
+    description: 'Galaxy fork to use. Affects both the pointing step and Galaxy package installation.'
     default: 'galaxyproject'
   python-version:
     description: 'Python version to use'

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
     - name: Install planemo
       run: |
         pip install wheel ${{ inputs.planemo-version }}
-        if [ "${{ inputs.galaxy-branch }}" ]; then
+        if [[ "${{ inputs.galaxy-branch }}" != "master" ]]; then
           echo "Installing Galaxy packages from branch: ${{ inputs.galaxy-branch }}"
           base="git+https://github.com/${{ inputs.galaxy-fork }}/galaxy.git@${{ inputs.galaxy-branch }}#subdirectory=packages"
           pip install --force-reinstall "$base/util" "$base/tool_util_models" "$base/tool_util"

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,13 @@ runs:
     # Install the `wheel` package so that when installing other packages which
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install planemo
-      run: pip install wheel ${{ inputs.planemo-version }}
+      run: |
+        pip install wheel ${{ inputs.planemo-version }}
+        if [ "${{ inputs.galaxy-branch }}" ]; then
+          echo "Installing Galaxy packages from branch: ${{ inputs.galaxy-branch }}"
+          base="git+https://github.com/${{ inputs.galaxy-fork }}/galaxy.git@${{ inputs.galaxy-branch }}#subdirectory=packages"
+          pip install --force-reinstall "$base/util" "$base/tool_util_models" "$base/tool_util"
+        fi
       shell: bash
     - name: Install jq
       run: sudo apt-get install jq


### PR DESCRIPTION
Enable installation of Galaxy packages from branches other than master, allowing for greater flexibility.

This will be useful, for example, when we want to run tool tests and lint in a specific branch that might not even be released.