### PR TITLE
Update cvmfs repo location

### DIFF
--- a/cvmfs/setup_cvmfs.sh
+++ b/cvmfs/setup_cvmfs.sh
@@ -4,7 +4,7 @@ set -x
 cd "${BASH_SOURCE%/*}/" || exit
 
 sudo apt install lsb-release
-wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+wget https://cvmrepo.s3.cern.ch/cvmrepo/apt/cvmfs-release-latest_all.deb
 sudo dpkg -i cvmfs-release-latest_all.deb
 sudo apt-get update
 sudo apt install cvmfs cvmfs-config


### PR DESCRIPTION
The CVMFS release package URL changed from ecsft.cern.ch to cvmrepo.s3.cern.ch. The old CERN endpoint has certificate verification issues. See https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html