### PR TITLE
Add retest mode to re-run only previously-failed tests per chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,65 @@ Optional inputs:
 - `galaxy-slots`: number of slots (threads) to use in Galaxy jobs (sets the `GALAXY_SLOTS` environment variable)
 - `test_timeout`:  Maximum runtime of a single test in seconds, default: 86400
 - `galaxy-user-key`: API key(s) used for testing agains online instances (note: use secrets for this). See "Assumptions on the repository".
+- `previous-run-id`: re-run only previously-failed tests (see "Retesting only previously-failed tests" below).
+- `github-token`: GitHub token used to download the previous run's artifacts (only needed together with `previous-run-id`).
 
 Output:
 
 The test mode creates a directory `upload/` containing the test results as json file.
+
+### Retesting only previously-failed tests
+
+Set `previous-run-id` to the run ID of an earlier run to re-test only the test cases
+that failed in that run instead of running the full test suite. When set, test mode:
+
+- downloads that run's `Tool test output {chunk}` artifact via `gh run download`
+  (the `gh` CLI is preinstalled on GitHub-hosted runners; on self-hosted runners it must
+  be installed. A valid `github-token` must be passed);
+- restricts the run to the previously-failed test cases via `planemo test --failed
+  --failed_json`, so only failed tests are submitted to the engine.
+
+The caller must pass the same `repository-list`, `chunk-count`, and `chunk` as the
+original run so that the identical tool groups are reconstructed. This requires planemo
+≥ the release that ships the `--failed`/`--failed_json` flags (see
+[galaxyproject/planemo#1653](https://github.com/galaxyproject/planemo/pull/1653)).
+
+The output is identical to a regular test run (a `tool_test_output.json`/`.html`
+uploaded as `Tool test output {chunk}`), so the `combine` and `check` modes work
+unchanged downstream.
+
+Example `workflow_dispatch` job:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      rerun-run-id:
+        description: 'Run ID of the previous run to re-test failures from'
+        required: true
+        type: string
+
+jobs:
+  retest:
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: galaxyproject/planemo-ci-action@main
+        with:
+          mode: test
+          repository-list: ${{ needs.setup.outputs.repository-list }}
+          chunk: ${{ matrix.chunk }}
+          chunk-count: ${{ needs.setup.outputs.chunk-count }}
+          previous-run-id: ${{ inputs.rerun-run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: 'Tool test output ${{ matrix.chunk }}'
+          path: upload
+```
 
 Combine test outputs mode
 -------------------------

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,9 @@ inputs:
   test_timeout:
     description: 'Maximum runtime of a single test in seconds, default: 0 means unlimited'
     default: 86400
+  previous-run-id:
+    description: 'Run ID of a previous workflow run to re-run failed tests from (used with mode: retest)'
+    default: ''
   # inputs that are needed for testing this action
   # not supposed to be used
   github-event-name-override:
@@ -160,6 +163,7 @@ runs:
         GALAXY_SLOTS: ${{ inputs.galaxy-slots }}
         TEST_TIMEOUT: ${{ inputs.test_timeout }}
         GALAXY_USER_KEY: ${{ inputs.galaxy-user-key }}
+        PREVIOUS_RUN_ID: ${{ inputs.previous-run-id }}
 
     - run: |
         echo 'repository-list<<EOF' >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ inputs:
     description: 'Maximum runtime of a single test in seconds, default: 0 means unlimited'
     default: 86400
   previous-run-id:
-    description: 'Run ID of a previous workflow run to re-run failed tests from (used with mode: retest)'
+    description: 'Run ID of a previous workflow run to re-run only failed tests from (used with mode: test). Requires the gh CLI and github-token.'
     default: ''
   # inputs that are needed for testing this action
   # not supposed to be used

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -222,6 +222,71 @@ if [ "$MODE" == "combine" ]; then
   jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | sed 's/"//g' | sort | uniq -c > statistics.txt
 fi
 
+# retest mode
+# - download artifact from a previous run using gh CLI
+# - for each chunk, re-run only the failed tests
+if [ "$MODE" == "retest" ]; then
+  if [ -z "$PREVIOUS_RUN_ID" ]; then
+    echo "PREVIOUS_RUN_ID must be set for retest mode" >&2
+    exit 1
+  fi
+
+  if [ "$WORKFLOWS" == "true" ] && [ "$SETUP_CVMFS" == "true" ]; then
+    "$GITHUB_ACTION_PATH"/cvmfs/setup_cvmfs.sh
+  fi
+
+  # Download the artifact for this specific chunk from the previous run
+  GH_TOKEN=$GITHUB_TOKEN gh run download "$PREVIOUS_RUN_ID" \
+    --name "Tool test output $CHUNK" \
+    --dir previous_run_results
+
+  PREVIOUS_JSON="previous_run_results/tool_test_output.json"
+  if [ ! -f "$PREVIOUS_JSON" ]; then
+    echo "No tool_test_output.json found in previous run artifact for chunk $CHUNK" >&2
+    exit 1
+  fi
+
+  # Find the same tools for this chunk as the original run
+  touch tool_list_chunk.txt
+  if [ -s repository_list.txt ]; then
+    mapfile -t REPO_ARRAY < repository_list.txt
+    if [ "$WORKFLOWS" != "true" ]; then
+      planemo ci_find_tools --chunk_count "$CHUNK_COUNT" --chunk "$CHUNK" --group_tools --output tool_list_chunk.txt "${REPO_ARRAY[@]}"
+    else
+      planemo ci_find_repos --chunk_count "$CHUNK_COUNT" --chunk "$CHUNK" --output tool_list_chunk.txt "${REPO_ARRAY[@]}"
+    fi
+  fi
+
+  cat tool_list_chunk.txt
+
+  mkdir -p json_output
+  touch .tt_biocontainer_skip
+  while read -r -a TOOL_GROUP; do
+    docker system prune --all --force --volumes || true
+    if echo "${TOOL_GROUP[@]}" | grep -qf .tt_biocontainer_skip; then
+      PLANEMO_OPTIONS=()
+    else
+      PLANEMO_OPTIONS=("${PLANEMO_CONTAINER_DEPENDENCIES[@]}")
+    fi
+    if [ "$WORKFLOWS" == "true" ]; then
+      PLANEMO_OPTIONS+=("${PLANEMO_WORKFLOW_OPTIONS[@]}")
+    fi
+    json=$(mktemp -u -p json_output --suff .json)
+    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" \
+      --failed --failed_json "$PREVIOUS_JSON" \
+      --test_output_json "$json" \
+      "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
+  done < tool_list_chunk.txt
+
+  if [ ! -s tool_list_chunk.txt ]; then
+    echo '{"tests":[]}' > "$(mktemp -u -p json_output --suff .json)"
+  fi
+
+  planemo merge_test_reports json_output/*.json tool_test_output.json
+  planemo test_reports tool_test_output.json --test_output tool_test_output.html
+  mv tool_test_output.json tool_test_output.html upload/
+fi
+
 # check outputs mode
 # - check if there were unsuccessful tests
 if [ "$MODE" == "check" ]; then

--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -146,6 +146,25 @@ if [ "$MODE" == "test" ]; then
     "$GITHUB_ACTION_PATH"/cvmfs/setup_cvmfs.sh
   fi
 
+  # Retest: if a previous run id is given, download that run's artifact for this
+  # chunk and restrict the test run to the previously-failed test cases via
+  # `--failed --failed_json`. When PREVIOUS_RUN_ID is empty this is a no-op and a
+  # regular full test run is performed.
+  RETEST_OPTIONS=()
+  if [ -n "$PREVIOUS_RUN_ID" ]; then
+    # gh is preinstalled on GitHub-hosted runners; guard for self-hosted runners.
+    command -v gh >/dev/null 2>&1 || { echo "gh CLI is required for retest (previous-run-id) but was not found" >&2; exit 1; }
+    GH_TOKEN=$GITHUB_TOKEN gh run download "$PREVIOUS_RUN_ID" \
+      --name "Tool test output $CHUNK" \
+      --dir previous_run_results
+    PREVIOUS_JSON="previous_run_results/tool_test_output.json"
+    if [ ! -f "$PREVIOUS_JSON" ]; then
+      echo "No tool_test_output.json found in previous run artifact for chunk $CHUNK" >&2
+      exit 1
+    fi
+    RETEST_OPTIONS=("--failed" "--failed_json" "$PREVIOUS_JSON")
+  fi
+
   # Find tools for chunk
   touch tool_list_chunk.txt
   if [ -s repository_list.txt ]; then
@@ -189,7 +208,7 @@ if [ "$MODE" == "test" ]; then
     fi
 
     json=$(mktemp -u -p json_output --suff .json)
-    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
+    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" "${RETEST_OPTIONS[@]}" --test_output_json "$json" "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
   done < tool_list_chunk.txt
 
   if [ ! -s tool_list_chunk.txt ]; then
@@ -220,71 +239,6 @@ if [ "$MODE" == "combine" ]; then
   )
   # get statistics
   jq '.["tests"][]["data"]["status"]' upload/tool_test_output.json | sed 's/"//g' | sort | uniq -c > statistics.txt
-fi
-
-# retest mode
-# - download artifact from a previous run using gh CLI
-# - for each chunk, re-run only the failed tests
-if [ "$MODE" == "retest" ]; then
-  if [ -z "$PREVIOUS_RUN_ID" ]; then
-    echo "PREVIOUS_RUN_ID must be set for retest mode" >&2
-    exit 1
-  fi
-
-  if [ "$WORKFLOWS" == "true" ] && [ "$SETUP_CVMFS" == "true" ]; then
-    "$GITHUB_ACTION_PATH"/cvmfs/setup_cvmfs.sh
-  fi
-
-  # Download the artifact for this specific chunk from the previous run
-  GH_TOKEN=$GITHUB_TOKEN gh run download "$PREVIOUS_RUN_ID" \
-    --name "Tool test output $CHUNK" \
-    --dir previous_run_results
-
-  PREVIOUS_JSON="previous_run_results/tool_test_output.json"
-  if [ ! -f "$PREVIOUS_JSON" ]; then
-    echo "No tool_test_output.json found in previous run artifact for chunk $CHUNK" >&2
-    exit 1
-  fi
-
-  # Find the same tools for this chunk as the original run
-  touch tool_list_chunk.txt
-  if [ -s repository_list.txt ]; then
-    mapfile -t REPO_ARRAY < repository_list.txt
-    if [ "$WORKFLOWS" != "true" ]; then
-      planemo ci_find_tools --chunk_count "$CHUNK_COUNT" --chunk "$CHUNK" --group_tools --output tool_list_chunk.txt "${REPO_ARRAY[@]}"
-    else
-      planemo ci_find_repos --chunk_count "$CHUNK_COUNT" --chunk "$CHUNK" --output tool_list_chunk.txt "${REPO_ARRAY[@]}"
-    fi
-  fi
-
-  cat tool_list_chunk.txt
-
-  mkdir -p json_output
-  touch .tt_biocontainer_skip
-  while read -r -a TOOL_GROUP; do
-    docker system prune --all --force --volumes || true
-    if echo "${TOOL_GROUP[@]}" | grep -qf .tt_biocontainer_skip; then
-      PLANEMO_OPTIONS=()
-    else
-      PLANEMO_OPTIONS=("${PLANEMO_CONTAINER_DEPENDENCIES[@]}")
-    fi
-    if [ "$WORKFLOWS" == "true" ]; then
-      PLANEMO_OPTIONS+=("${PLANEMO_WORKFLOW_OPTIONS[@]}")
-    fi
-    json=$(mktemp -u -p json_output --suff .json)
-    PIP_QUIET=1 planemo test "${PLANEMO_OPTIONS[@]}" "${PLANEMO_TEST_OPTIONS[@]}" \
-      --failed --failed_json "$PREVIOUS_JSON" \
-      --test_output_json "$json" \
-      "${TOOL_GROUP[@]}" "${ADDITIONAL_PLANEMO_OPTIONS[@]}" || true
-  done < tool_list_chunk.txt
-
-  if [ ! -s tool_list_chunk.txt ]; then
-    echo '{"tests":[]}' > "$(mktemp -u -p json_output --suff .json)"
-  fi
-
-  planemo merge_test_reports json_output/*.json tool_test_output.json
-  planemo test_reports tool_test_output.json --test_output tool_test_output.html
-  mv tool_test_output.json tool_test_output.html upload/
 fi
 
 # check outputs mode


### PR DESCRIPTION
## Summary

Adds a `retest` mode and a `previous-run-id` input. When `mode: retest` is used:

1. Downloads the `Tool test output {chunk}` artifact from the run specified by
   `previous-run-id` via `gh run download`
2. Finds the same tool groups for this chunk (same `repository-list`,
   `chunk-count`, and `chunk` as the original run)
3. Runs `planemo test --failed --failed_json previous_run_results/tool_test_output.json`
   for each tool group — only test cases that previously failed are submitted to
   the engine

The output is the same as `test` mode: a merged `tool_test_output.json` and
`.html` report uploaded as the `Tool test output {chunk}` artifact, so the
existing `combine` and `check` modes work unchanged downstream.

## Requires

Planemo ≥ next release (or the `--lf` PR: galaxyproject/planemo#1653) for the
`--failed` / `--failed_json` flags.

## Usage in a workflow

```yaml
on:
  workflow_dispatch:
    inputs:
      rerun-run-id:
        description: 'Run ID of the previous weekly run to re-test failures from'
        required: true
        type: string

jobs:
  retest:
    strategy:
      fail-fast: false
      matrix:
        chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
    steps:
      - uses: actions/checkout@v4
      - uses: galaxyproject/planemo-ci-action@main
        with:
          mode: retest
          repository-list: ${{ needs.setup.outputs.repository-list }}
          chunk: ${{ matrix.chunk }}
          chunk-count: ${{ needs.setup.outputs.chunk-count }}
          previous-run-id: ${{ inputs.rerun-run-id }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
      - uses: actions/upload-artifact@v4
        with:
          name: 'Tool test output ${{ matrix.chunk }}'
          path: upload
```

## Test plan

- [ ] Trigger a weekly run, let some tests fail
- [ ] Note the run ID
- [ ] Trigger `workflow_dispatch` with that run ID
- [ ] Confirm only the previously-failed tools/tests are executed per chunk
- [ ] Confirm the combined report reflects only the retested results