### PR TITLE
Run test-workflows job in pr-secrets environment

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -182,6 +182,10 @@ jobs:
     name: Test testing of workflows
     needs: [setup-ci-workflows]
     runs-on: ubuntu-latest
+    # example3 carries a .wt_instance file pointing at usegalaxy.org, so this
+    # job tests against that external instance and needs GALAXY_USER_KEY, which
+    # is only available through the pr-secrets environment.
+    environment: pr-secrets
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

CI on `main` fails in the `Test testing of workflows (0, 3.11)` chunk ([example run](https://github.com/galaxyproject/planemo-ci-action/actions/runs/28396271225/job/84136606245)):

```
+ planemo test --galaxy_url https://usegalaxy.org --test_output_json ... test/workflows/example3
bioblend.ConnectionError: GET: error 401: {"err_msg":"Provided API key is not valid.","err_code":401001}
```

`test/workflows/example3` carries a `.wt_instance` file pointing at `usegalaxy.org` (added in #64), so the `test-workflows` job tests against that external instance and needs `GALAXY_USER_KEY`. That secret only lives in the `pr-secrets` environment, but the job did not declare `environment: pr-secrets` — so the key came through empty (note the `Can't add secret mask for empty string` warning) and planemo hit usegalaxy.org unauthenticated, failing with the 401. The subsequent `mv: cannot stat 'tool_test_output.json'` is just the downstream symptom.

This is the planemo-ci-action counterpart to the external-instance testing feature (galaxyproject/iwc#1264), which works because the iwc repos gate the test job behind the environment holding the key.

## Fix

Declare `environment: pr-secrets` on the `test-workflows` job so `secrets.GALAXY_USER_KEY` is populated.

## Notes

- Runs of this job will now pause for IWC-team approval to access the `pr-secrets` environment (by design of the feature).
- The `2nd run test workflows` step shares the same job, so it is covered too.
- Unrelated: when an external test fails, the step still dies at the `mv` with a confusing "cannot stat" error instead of a real report (`planemo_ci_actions.sh` guards `planemo test` with `|| true` but not `merge_test_reports`/`test_reports`). Left for a separate hardening PR.