### PR TITLE
Persist shed data-table config via --shed_data_dir (fixes iwc#1294)

### DIFF
--- a/planemo_ci_actions.sh
+++ b/planemo_ci_actions.sh
@@ -4,7 +4,16 @@ set -exo pipefail
 
 PLANEMO_TEST_OPTIONS=("--database_connection" "$DATABASE_CONNECTION" "--galaxy_source" "https://github.com/$GALAXY_FORK/galaxy" "--galaxy_branch" "$GALAXY_BRANCH" "--galaxy_python_version" "$PYTHON_VERSION" --test_timeout "$TEST_TIMEOUT")
 PLANEMO_CONTAINER_DEPENDENCIES=("--biocontainers" "--no_dependency_resolution" "--no_conda_auto_init" "--docker_extra_volume" "./")
-PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs" --shed_tool_conf /tmp/shed_tool_conf.xml --shed_tool_path /tmp/shed_dir)
+PLANEMO_WORKFLOW_OPTIONS=("--tool_data_table" "/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml" "--tool_data_table" "/cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml" "--docker_extra_volume" "/cvmfs")
+# Persist shed-install state across the per-line `planemo test` invocations of a
+# chunk. --shed_data_dir (planemo >= 0.75.45) also persists the shed tool-data-table
+# and data-manager configs, so reused tools keep their registered data tables
+# (see galaxyproject/iwc#1294). Fall back to the older flags on earlier planemo.
+if planemo test --help 2>/dev/null | grep -q -- --shed_data_dir; then
+  PLANEMO_WORKFLOW_OPTIONS+=(--shed_data_dir /tmp/shed_data)
+else
+  PLANEMO_WORKFLOW_OPTIONS+=(--shed_tool_conf /tmp/shed_tool_conf.xml --shed_tool_path /tmp/shed_dir)
+fi
 read -ra ADDITIONAL_PLANEMO_OPTIONS <<< "$ADDITIONAL_PLANEMO_OPTIONS"
 
 


### PR DESCRIPTION
Persist shed-install state across the per-line `planemo test` invocations of a workflow-test chunk so that reused tools keep their registered tool data tables.

## Problem

Within a chunk, `planemo test` is invoked once per workflow line, all sharing fixed `/tmp` shed paths. Previously only `--shed_tool_conf` and `--shed_tool_path` were persisted — the shed **tool-data-table** and **data-manager** configs went to planemo's ephemeral per-run config dir. So when a shed-installed tool was reused in a later invocation of the same chunk, its data-table column registration was gone, surfacing as e.g. `ValueError: invalid literal for int() with base 10: 'dbkey'` for featurecounts even though the tool installed and works on production Galaxy.

Fixes galaxyproject/iwc#1294.

## Change

Replace the two hard-coded flags with `--shed_data_dir /tmp/shed_data` (planemo >= 0.75.45, added in galaxyproject/planemo#1656), which cascades a single base directory to `--shed_tool_conf`, `--shed_tool_path`, `shed_tool_data_table_config` and `shed_data_manager_config_file` — persisting all four.

The flag is **feature-detected** (`planemo test --help | grep -q -- --shed_data_dir`); on older planemo it falls back to the previous two-flag behavior, so pinning an older `planemo-version` still works.
